### PR TITLE
Fix(App): Correctly load file metadata in dashboard

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -204,12 +204,12 @@ const FileUpload = ({ openDialog }) => {
             size: file.file_size,
             data: fileData, // Dati completi per la dashboard
             metadata: {
-              totalAgents: file.total_agents,
-              totalSMs: file.total_sms,
-              totalRevenue: file.total_revenue,
-              totalInflow: file.total_inflow,
-              totalNewClients: file.total_new_clients,
-              totalFastweb: file.total_fastweb
+              totalAgents: fileData.metadata.totalAgents,
+              totalSMs: fileData.metadata.totalSMs,
+              totalRevenue: fileData.totals.fatturato,
+              totalInflow: fileData.totals.inflow,
+              totalNewClients: fileData.totals.nuoviClienti,
+              totalFastweb: fileData.totals.fastwebEnergia || 0
             }
           };
         } catch (error) {


### PR DESCRIPTION
The dashboard was showing zero for "fatturato totale" and "inflow" after a file was uploaded and the data was reloaded.

This was caused by a bug in the `loadFiles` function in `App.js`. When reconstructing the file list after fetching data from the server, the component was using stale summary data instead of the complete, freshly-loaded data object to populate the UI state.

The fix involves updating the `metadata` population logic to use the correct data source (`fileData.totals` and `fileData.metadata`) which contains the accurate, parsed values. This ensures the dashboard reflects the correct totals immediately after the file list is refreshed.