### PR TITLE
Fix(App): Ensure correct data source for dashboard metrics

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -206,10 +206,10 @@ const FileUpload = ({ openDialog }) => {
             metadata: {
               totalAgents: fileData.metadata.totalAgents,
               totalSMs: fileData.metadata.totalSMs,
-              totalRevenue: fileData.totals.fatturato,
-              totalInflow: fileData.totals.inflow,
-              totalNewClients: fileData.totals.nuoviClienti,
-              totalFastweb: fileData.totals.fastwebEnergia || 0
+              totalRevenue: fileData.metadata.totalRevenue,
+              totalInflow: fileData.metadata.totalInflow,
+              totalNewClients: fileData.metadata.totalNewClients,
+              totalFastweb: fileData.metadata.totalFastweb || 0
             }
           };
         } catch (error) {


### PR DESCRIPTION
This commit fixes a bug where the dashboard would display zero for key metrics like "fatturato" and "inflow" after a file upload.

The root cause was an incorrect data mapping in the `loadFiles` function. The application was trying to read summary data from one object while the complete, correct data was available in a nested object (`fileData.metadata`).

This patch corrects the mapping to consistently use `fileData.metadata` as the single source of truth for all metrics being passed to the UI. This resolves the data discrepancy and ensures the dashboard is always in sync with the latest parsed file data.