### PR TITLE
Feat(Dashboard): Implement period selection functionality

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -235,6 +235,9 @@ body {
 }
 
 .dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 32px;
 }
 
@@ -783,4 +786,38 @@ input:focus-visible {
 
 .toast-loading {
   background: linear-gradient(135deg, #2196f3 0%, #42a5f5 100%) !important;
+}
+
+/* Styling for the new Period Selector */
+.period-selector {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.period-selector label {
+  font-weight: 500;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.period-selector select {
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background-color: #f9f9f9;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s;
+  min-width: 150px;
+}
+
+.period-selector select:hover {
+  border-color: #1976d2;
+}
+
+.period-selector select:focus {
+  outline: none;
+  border-color: #1976d2;
+  box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.2);
 }


### PR DESCRIPTION
This commit introduces a new feature that allows users to select a specific period (from the list of uploaded files) to display on the dashboard.

Key changes include:
- A new state variable (`selectedFileDate`) was added to manage the currently selected period.
- A dropdown (`<select>`) UI component was added to the Dashboard header, allowing users to choose from available periods.
- The Dashboard's data-rendering logic was updated to be driven by the selected period, defaulting to the most recent file.
- Added a `useEffect` to handle default selection and to reset the selection if the chosen file is deleted.
- Added CSS to style the new dropdown for a consistent look and feel.