### PR TITLE
feat: Refine dashboard UX and layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -274,6 +274,17 @@ body {
   transform: translateY(-5px);
 }
 
+.stat-card.highlight {
+  grid-column: span 2;
+  background-color: #e3f2fd; /* Un colore di sfondo leggermente diverso */
+}
+
+@media (max-width: 768px) {
+  .stat-card.highlight {
+    grid-column: span 1; /* Su mobile, le card tornano a colonna singola */
+  }
+}
+
 .stat-card h3 {
   color: var(--text-secondary);
   font-size: 14px;

--- a/src/App.js
+++ b/src/App.js
@@ -556,11 +556,6 @@ const Dashboard = () => {
       </div>
       
       <div className="stats-grid">
-        <div className="stat-card" style={{ animationDelay: '100ms' }}>
-          <h3>File Caricati</h3>
-          <div className={`stat-number ${loading ? 'loading' : ''}`}>{data.uploadedFiles.length}</div>
-        </div>
-        
         <div className="stat-card" style={{ animationDelay: '200ms' }}>
           <h3>Totale Agenti</h3>
           <div className={`stat-number ${loading ? 'loading' : ''}`}>{formatNumber(stats.totalAgents)}</div>
@@ -571,12 +566,12 @@ const Dashboard = () => {
           <div className={`stat-number ${loading ? 'loading' : ''}`}>{formatNumber(stats.totalSMs)}</div>
         </div>
         
-        <div className="stat-card" style={{ animationDelay: '400ms' }}>
+        <div className="stat-card highlight" style={{ animationDelay: '400ms' }}>
           <h3>Fatturato Totale</h3>
           <div className={`stat-number ${loading ? 'loading' : ''}`}>{formatCurrency(stats.totalRevenue)}</div>
         </div>
         
-        <div className="stat-card" style={{ animationDelay: '500ms' }}>
+        <div className="stat-card highlight" style={{ animationDelay: '500ms' }}>
           <h3>Inflow Totale</h3>
           <div className={`stat-number ${loading ? 'loading' : ''}`}>{formatCurrency(stats.totalInflow)}</div>
         </div>


### PR DESCRIPTION
This commit introduces further refinements to the dashboard's user experience based on user feedback:

- Removes the 'File Caricati' card from the dashboard to focus on more relevant metrics.
- Highlights the 'Fatturato Totale' and 'Inflow Totale' cards by making them larger and giving them a distinct background color, drawing user attention to key performance indicators.