### PR TITLE
feat: Add Agents component with interactive data grid

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import { apiService } from './services/apiService';
 // Import del parser Excel aggiornato
 import { parseExcelFile, formatCurrency, formatNumber, sortFilesByDate } from './utils/excelParser';
 import ConfirmationDialog from './components/ConfirmationDialog';
+import Agents from './components/Agents'; // Importa il nuovo componente
 import './App.css';
 
 // Context per la gestione dei dati
@@ -662,7 +663,7 @@ const MainApp = ({ currentUser, onLogout }) => {
       case 'sm-ranking':
         return <div className="section-placeholder">🏅 Classifica SM - Disponibile dopo caricamento componenti avanzati</div>;
       case 'agents':
-        return <div className="section-placeholder">👥 Dettagli Agenti - Disponibile dopo caricamento componenti avanzati</div>;
+        return <Agents />;
       case 'products':
         return <div className="section-placeholder">📦 Analisi Prodotti - Disponibile dopo caricamento componenti avanzati</div>;
       case 'new-clients':

--- a/src/components/Agents.css
+++ b/src/components/Agents.css
@@ -1,0 +1,163 @@
+/* Contenitore principale */
+.agents-container {
+    padding: 20px;
+    background-color: #f9f9f9;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    animation: fadeIn 0.5s ease-in-out;
+}
+
+/* Header della sezione Agenti */
+.agents-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+    padding-bottom: 15px;
+    border-bottom: 2px solid #eee;
+}
+
+.agents-header h2 {
+    margin: 0;
+    font-size: 1.8rem;
+    color: #333;
+}
+
+/* Stile per il selettore del periodo */
+.period-selector {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.period-selector label {
+    font-weight: 600;
+    color: #555;
+}
+
+.period-selector select {
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid #ccc;
+    background-color: #fff;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.period-selector select:hover {
+    border-color: #1976d2;
+}
+
+.period-selector select:focus {
+    outline: none;
+    border-color: #1976d2;
+    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.2);
+}
+
+/* Contenitore della DataGrid con effetto di caricamento */
+.data-grid-container {
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    transition: opacity 0.3s ease-in-out;
+    height: 70vh; /* Altezza per la griglia */
+}
+
+.data-grid-container.loading {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+/* Stile per la DataGrid */
+.MuiDataGrid-root {
+    border: none !important;
+    font-family: 'Roboto', sans-serif;
+}
+
+.MuiDataGrid-columnHeaders {
+    background-color: #f1f5f9;
+    border-bottom: 2px solid #e0e0e0;
+    font-weight: 600;
+}
+
+.MuiDataGrid-columnHeaderTitle {
+    font-weight: 700 !important;
+    color: #334155;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+}
+
+.MuiDataGrid-cell {
+    border-bottom: 1px solid #eee;
+}
+
+.MuiDataGrid-row:hover {
+    background-color: #f5faff !important;
+}
+
+/* Stili specifici per le celle */
+.agent-cell {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    line-height: 1.2;
+    padding: 5px 0;
+}
+
+.agent-name {
+    font-weight: 600;
+    color: #1e3a8a;
+}
+
+.agent-sm {
+    font-size: 0.85rem;
+    color: #64748b;
+}
+
+.currency-cell {
+    font-weight: 500;
+    text-align: right;
+    width: 100%;
+    color: #166534;
+}
+
+.currency-cell.highlight {
+    font-weight: 700;
+    color: #059669;
+}
+
+.number-cell {
+    font-weight: 500;
+    text-align: right;
+    width: 100%;
+}
+
+/* Messaggio di dati non disponibili */
+.no-data-message {
+    text-align: center;
+    padding: 50px;
+    color: #777;
+}
+
+.no-data-message h3 {
+    margin-bottom: 10px;
+}
+
+/* Stile per la barra degli strumenti della DataGrid */
+.MuiGridToolbar-root {
+    padding: 10px;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+/* Animazioni */
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/src/components/Agents.js
+++ b/src/components/Agents.js
@@ -1,0 +1,164 @@
+import React, { useState, useMemo } from 'react';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { useData } from '../App';
+import { formatCurrency, formatNumber } from '../utils/excelParser';
+import './Agents.css';
+
+const Agents = () => {
+  const { data, selectedFileDate, setSelectedFileDate } = useData();
+  const [loading, setLoading] = useState(false);
+
+  const { agents, currentFile } = useMemo(() => {
+    if (!selectedFileDate || data.uploadedFiles.length === 0) {
+      return { agents: [], currentFile: null };
+    }
+
+    const file = data.uploadedFiles.find(f => f.date === selectedFileDate);
+    if (!file || !file.data || !file.data.agents) {
+      return { agents: [], currentFile: null };
+    }
+
+    // Aggiungi un id univoco per ogni riga, necessario per la DataGrid
+    const agentsWithId = file.data.agents.map((agent, index) => ({
+      id: `${file.date}-${agent.numero}-${index}`,
+      ...agent,
+    }));
+
+    return { agents: agentsWithId, currentFile: file };
+  }, [data.uploadedFiles, selectedFileDate]);
+
+  const handlePeriodChange = (e) => {
+    const newFileDate = e.target.value;
+    setLoading(true);
+    setTimeout(() => {
+      setSelectedFileDate(newFileDate);
+      setLoading(false);
+    }, 500);
+  };
+
+  // Definizione delle colonne per la DataGrid
+  const columns = [
+    { field: 'numero', headerName: 'N.', width: 70, type: 'number' },
+    { field: 'nome', headerName: 'Agente', width: 200,
+      renderCell: (params) => (
+        <div className="agent-cell">
+          <div className="agent-name">{params.value}</div>
+          <div className="agent-sm">{params.row.sm}</div>
+        </div>
+      )
+    },
+    { field: 'sm', headerName: 'SM', width: 150 },
+    {
+      field: 'fatturato.complessivo',
+      headerName: 'Fatturato',
+      width: 130,
+      type: 'number',
+      valueGetter: (params) => params.row.fatturato.complessivo,
+      renderCell: (params) => (
+        <div className="currency-cell">{formatCurrency(params.value)}</div>
+      ),
+    },
+    {
+      field: 'inflowTotale',
+      headerName: 'Inflow',
+      width: 130,
+      type: 'number',
+      renderCell: (params) => (
+        <div className="currency-cell highlight">{formatCurrency(params.value)}</div>
+      ),
+    },
+    {
+      field: 'nuoviClienti',
+      headerName: 'Nuovi Clienti',
+      width: 120,
+      type: 'number',
+      renderCell: (params) => (
+        <div className="number-cell">{formatNumber(params.value)}</div>
+      ),
+    },
+    {
+      field: 'fastwebEnergia',
+      headerName: 'Fastweb',
+      width: 100,
+      type: 'number',
+      renderCell: (params) => (
+        <div className="number-cell">{params.value > 0 ? formatNumber(params.value) : '--'}</div>
+      ),
+    },
+    {
+      field: 'totaliProdotti.pezziTotali',
+      headerName: 'Pezzi Totali',
+      width: 120,
+      type: 'number',
+      valueGetter: (params) => params.row.totaliProdotti.pezziTotali,
+      renderCell: (params) => (
+        <div className="number-cell">{formatNumber(params.value)}</div>
+      ),
+    },
+    { field: 'distretto', headerName: 'Distretto', width: 130 },
+    { field: 'tipologia', headerName: 'Tipologia', width: 120 },
+  ];
+
+  return (
+    <div className="agents-container">
+      <div className="agents-header">
+        <h2>👥 Dettaglio Agenti</h2>
+        {data.uploadedFiles.length > 0 && currentFile ? (
+          <div className="period-selector">
+            <label htmlFor="agent-period-select">Periodo di Riferimento:</label>
+            <select
+              id="agent-period-select"
+              value={currentFile.date}
+              onChange={handlePeriodChange}
+              disabled={loading}
+            >
+              {data.uploadedFiles.map(file => (
+                <option key={file.id} value={file.date}>
+                  {file.displayDate}
+                </option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <p className="current-period">Nessun periodo disponibile</p>
+        )}
+      </div>
+
+      <div className={`data-grid-container ${loading ? 'loading' : ''}`}>
+        {agents.length > 0 ? (
+          <DataGrid
+            rows={agents}
+            columns={columns}
+            pageSize={10}
+            rowsPerPageOptions={[10, 25, 50, 100]}
+            autoHeight
+            components={{
+              Toolbar: GridToolbar,
+            }}
+            componentsProps={{
+              toolbar: {
+                showQuickFilter: true,
+                quickFilterProps: { debounceMs: 500 },
+              },
+            }}
+            initialState={{
+              sorting: {
+                sortModel: [{ field: 'inflowTotale', sort: 'desc' }],
+              },
+            }}
+            getRowClassName={(params) =>
+              `agent-row ${params.row.inflowTotale > 0 ? 'positive-inflow' : ''}`
+            }
+          />
+        ) : (
+          <div className="no-data-message">
+            <h3>Nessun dato disponibile per il periodo selezionato.</h3>
+            <p>Carica un file o seleziona un altro periodo.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Agents;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill for TextEncoder and TextDecoder for Jest
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
This commit introduces a new `Agents` component to display agent data in an interactive table.

- Created the `Agents.js` component, which uses the Material-UI DataGrid to provide sorting, filtering, and pagination.
- The component fetches data from the existing `DataContext` and updates dynamically when the selected period changes.
- Custom cell renderers are used to format currency and numbers for better readability.
- Added `Agents.css` for styling the new component.
- Integrated the `Agents` component into the main `App.js`, replacing the placeholder.
- Fixed a test failure by adding a polyfill for `TextEncoder` in `src/setupTests.js`, which is required by `@mui/x-data-grid` in a JSDOM environment.