### PR TITLE
feat: Add test page to display agent data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { apiService } from './services/apiService';
 import { parseExcelFile, formatCurrency, formatNumber, sortFilesByDate } from './utils/excelParser';
 import ConfirmationDialog from './components/ConfirmationDialog';
 import Agents from './components/Agents'; // Importa il nuovo componente
+import TestPage from './components/TestPage'; // Importa il componente TestPage
 import './App.css';
 
 // Context per la gestione dei dati - AGGIORNATO con caricamento globale
@@ -311,6 +312,7 @@ const Sidebar = ({ activeSection, setActiveSection, currentUser, onLogout, openD
     { id: 'new-clients', label: 'Nuovi Clienti', icon: '🆕' },
     { id: 'fastweb', label: 'Fastweb', icon: '⚡' },
     { id: 'files', label: 'Gestione File', icon: '📁' },
+    { id: 'test', label: 'Test', icon: '🧪' },
   ];
 
   const handleLogout = async () => {
@@ -811,6 +813,8 @@ const MainApp = ({ currentUser, onLogout, isAuthenticated }) => {
         return <div className="section-placeholder">🆕 Nuovi Clienti - Disponibile dopo caricamento componenti avanzati</div>;
       case 'fastweb':
         return <div className="section-placeholder">⚡ Contratti Fastweb - Disponibile dopo caricamento componenti avanzati</div>;
+      case 'test':
+        return <TestPage />;
       default:
         return <Dashboard />;
     }

--- a/src/components/TestPage.css
+++ b/src/components/TestPage.css
@@ -1,0 +1,35 @@
+.test-page-container {
+  padding: 20px;
+  font-family: Arial, sans-serif;
+}
+
+.table-container {
+  overflow-x: auto;
+  margin-top: 20px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+thead {
+  background-color: #f2f2f2;
+}
+
+th {
+  font-weight: bold;
+}
+
+tr:nth-child(even) {
+  background-color: #f9f9f9;
+}

--- a/src/components/TestPage.js
+++ b/src/components/TestPage.js
@@ -1,0 +1,69 @@
+import React, { useMemo } from 'react';
+import { useData } from '../App';
+import './TestPage.css';
+
+const TestPage = () => {
+  const { data, selectedFileDate } = useData();
+
+  const { agents, agentKeys } = useMemo(() => {
+    if (!selectedFileDate || !data.processedData[selectedFileDate]) {
+      return { agents: [], agentKeys: [] };
+    }
+
+    const allAgents = data.processedData[selectedFileDate].agents;
+    const firstTenAgents = allAgents.slice(0, 10);
+
+    if (firstTenAgents.length === 0) {
+      return { agents: [], agentKeys: [] };
+    }
+
+    // Get all unique keys from the first 10 agents
+    const keys = new Set();
+    firstTenAgents.forEach(agent => {
+      Object.keys(agent).forEach(key => keys.add(key));
+    });
+    const sortedKeys = Array.from(keys).sort();
+
+
+    return { agents: firstTenAgents, agentKeys: sortedKeys };
+  }, [data, selectedFileDate]);
+
+  if (agents.length === 0) {
+    return (
+      <div className="test-page-container">
+        <h2>Test Page - Dati Agenti</h2>
+        <p>Nessun dato disponibile per il file selezionato o nessun file caricato.</p>
+        <p>Vai su "Gestione File" per caricare un file.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="test-page-container">
+      <h2>Test Page - Primi 10 Agenti</h2>
+      <p>Questa tabella mostra i dati grezzi dei primi 10 agenti importati dal file per il debug della mappatura.</p>
+      <div className="table-container">
+        <table>
+          <thead>
+            <tr>
+              {agentKeys.map(key => (
+                <th key={key}>{key}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {agents.map((agent, index) => (
+              <tr key={index}>
+                {agentKeys.map(key => (
+                  <td key={key}>{typeof agent[key] === 'object' ? JSON.stringify(agent[key]) : agent[key]}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default TestPage;


### PR DESCRIPTION
This commit introduces a new 'Test' page accessible from the sidebar. The page displays a table with the raw data of the first 10 agents from the selected file. This feature is intended for debugging and verifying the correctness of the data mapping from the Excel parser.