### PR TITLE
feat: Aggiorna le soglie dei filtri preset per il fatturato

### DIFF
--- a/src/components/ModernAgentsPage.js
+++ b/src/components/ModernAgentsPage.js
@@ -77,13 +77,13 @@ const ModernAgentsPage = () => {
     let newFilters = { ...filters, searchTerm: '', selectedSm: '', activePreset: preset };
     switch (preset) {
       case 'top':
-        newFilters.fatturatoRushRange = [Math.floor(maxFatturatoRush * 0.7), maxFatturatoRush];
+        newFilters.fatturatoRushRange = [1000, maxFatturatoRush];
         break;
       case 'underperforming':
-        newFilters.fatturatoRushRange = [0, Math.floor(maxFatturatoRush * 0.3)];
+        newFilters.fatturatoRushRange = [0, 500];
         break;
       case 'average':
-        newFilters.fatturatoRushRange = [Math.floor(maxFatturatoRush * 0.3), Math.floor(maxFatturatoRush * 0.7)];
+        newFilters.fatturatoRushRange = [500, 1000];
         break;
       default:
         newFilters.fatturatoRushRange = [0, maxFatturatoRush];


### PR DESCRIPTION
- Modifica la funzione `handlePresetFilter` in `ModernAgentsPage.js` per utilizzare valori fissi per i filtri rapidi del fatturato rush.
- Le nuove soglie sono:
  - Basso: 0 - 500
  - Medio: 500 - 1000
  - Alto: > 1000
- Questa modifica allinea il comportamento dei filtri alle specifiche fornite dall'utente per una categorizzazione più precisa della performance.