### PR TITLE
feat: Format agent names for display

### DIFF
--- a/src/components/AgentModal.js
+++ b/src/components/AgentModal.js
@@ -65,7 +65,7 @@ const AgentModal = ({ agent, allData, onClose }) => {
     }
     return allData.uploadedFiles
       .map(file => {
-        const agentData = file.data?.agents?.find(a => a.nome === agent.nome);
+        const agentData = file.data?.agents?.find(a => a.nome === agent.originalNome);
         return agentData ? {
           name: file.displayDate, // Mappato da 'period' a 'name' per il grafico
           rush: agentData.fatturatoRush || 0, // Mappato da 'fatturatoRush' a 'rush'

--- a/src/components/ModernAgentsPage.js
+++ b/src/components/ModernAgentsPage.js
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useData } from '../App'; // Importa il context
+import { formatAgentName } from '../utils/formatter';
 import AgentCard from './AgentCard'; // Importa la VERA AgentCard
 import AgentModal from './AgentModal'; // Importa la VERA AgentModal
 import './ModernAgentsPage.css';
@@ -57,7 +58,10 @@ const ModernAgentsPage = () => {
     }
 
     const agentsWithId = file.data.agents.map((agent, index) => ({
-      id: `${file.date}-${agent.nome}-${index}`, ...agent,
+      ...agent,
+      id: `${file.date}-${agent.nome}-${index}`,
+      originalNome: agent.nome,
+      nome: formatAgentName(agent.nome),
     }));
 
     const uniqueSmList = [...new Set(agentsWithId.map(a => a.sm).filter(Boolean))].sort();

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -1,0 +1,9 @@
+export const formatAgentName = (name) => {
+  if (typeof name !== 'string' || !name) {
+    return 'N/A';
+  }
+  return name
+    .split('.')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+};


### PR DESCRIPTION
- Creates a utility function `formatAgentName` to convert names from `name.surname` to `Name Surname`.
- Modifies `ModernAgentsPage.js` to use this function for displaying agent names.
- Preserves the original name format in an `originalNome` property to ensure historical data lookups in `AgentModal.js` continue to function correctly.
- Updates `AgentModal.js` to use the `originalNome` property for these lookups.
- This change improves the user interface by presenting agent names in a more readable and professional format.