### PR TITLE
feat: Format agent and SM names across the application

### DIFF
--- a/src/components/ModernAgentsPage.js
+++ b/src/components/ModernAgentsPage.js
@@ -68,7 +68,8 @@ const ModernAgentsPage = () => {
     const trueMaxRush = Math.max(...agentsWithId.map(a => a.fatturatoRush || 0));
 
     let filteredAgents = agentsWithId.filter(agent =>
-      agent.nome.toLowerCase().includes(filters.searchTerm.toLowerCase()) &&
+      (agent.nome.toLowerCase().includes(filters.searchTerm.toLowerCase()) ||
+      (agent.originalNome && agent.originalNome.toLowerCase().includes(filters.searchTerm.toLowerCase()))) &&
       (filters.selectedSm === '' || agent.sm === filters.selectedSm) &&
       (agent.fatturatoRush || 0) >= filters.fatturatoRushRange[0] &&
       (agent.fatturatoRush || 0) <= filters.fatturatoRushRange[1]

--- a/src/components/ModernDashboard.js
+++ b/src/components/ModernDashboard.js
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { useData } from '../App';
+import { formatAgentName } from '../utils/formatter';
 import './ModernDashboard.css';
 import {
   BarChart3, Users, Crown, Activity, TrendingUp,
@@ -126,8 +127,8 @@ const ModernDashboard = () => {
                   <Crown size={24} className="text-yellow-500" />
                 </div>
                 <div className="performer-info">
-                  <h4>{stats.topAgent.nome}</h4>
-                  <p>{stats.topAgent.sm}</p>
+                  <h4>{formatAgentName(stats.topAgent.nome)}</h4>
+                  <p>{formatAgentName(stats.topAgent.sm)}</p>
                   <div className="performer-stats">
                     <span><TrendingUp size={14} />{formatCurrency(stats.topAgent.fatturatoRush || 0)}</span>
                     <span><DollarSign size={14} />{formatCurrency(stats.topAgent.fatturato?.complessivo || 0)}</span>

--- a/src/components/ModernProductsAnalysis.js
+++ b/src/components/ModernProductsAnalysis.js
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useData } from '../App';
+import { formatAgentName } from '../utils/formatter';
 import './ModernProductsAnalysis.css';
 import {
   Package, Smartphone, Globe, Zap, Phone, Award,
@@ -128,7 +129,7 @@ const ModernProductsAnalysis = () => {
           volume: agentsWithProduct.reduce((sum, item) => sum + item.volume, 0),
           fatturato: agentsWithProduct.reduce((sum, item) => sum + item.fatturato, 0),
           agents: agentsWithProduct.length,
-          topAgents: agentsWithProduct.slice(0, 3).map(item => item.nome)
+          topAgents: agentsWithProduct.slice(0, 3).map(item => formatAgentName(item.nome))
         };
       }
     });

--- a/src/components/ModernSMRanking.js
+++ b/src/components/ModernSMRanking.js
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useData } from '../App';
+import { formatAgentName } from '../utils/formatter';
 import {
   Trophy, Crown, Medal, Target, Users, TrendingUp,
   DollarSign, Filter,
@@ -289,7 +290,7 @@ const ModernSMRanking = () => {
                 </div>
 
                 <div className="sm-info">
-                  <h3 className="sm-name">{sm.name}</h3>
+                  <h3 className="sm-name">{formatAgentName(sm.name)}</h3>
                   <div className="sm-meta">
                     <span className="team-count">
                       <Users size={14} />
@@ -370,7 +371,7 @@ const ModernSMRanking = () => {
                   <div className="team-header">
                     <h4>
                       <Star size={16} />
-                      Team di {sm.name}
+                      Team di {formatAgentName(sm.name)}
                     </h4>
                   </div>
 
@@ -381,7 +382,7 @@ const ModernSMRanking = () => {
                           #{agentIndex + 1}
                         </div>
                         <div className="agent-info">
-                          <h5 className="agent-name">{agent.nome}</h5>
+                          <h5 className="agent-name">{formatAgentName(agent.nome)}</h5>
                           <div className="agent-metrics">
                             <div className="agent-metric">
                               <span className="label">Rush:</span>


### PR DESCRIPTION
- Creates a utility function `formatAgentName` to convert names from `name.surname` to `Name Surname`.
- Applies this formatting to agent and SM names in the Dashboard, SM Ranking, and Products Analysis pages.
- Modifies `ModernAgentsPage.js` to preserve the original name while displaying the formatted name.
- Updates the search in `ModernAgentsPage.js` to work with both original and formatted names.
- Updates `AgentModal.js` to use the original name for historical data lookups.

This change improves the user interface by presenting names in a more readable and professional format consistently across all sections.