### PR TITLE
feat: Create new clients page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import ConfirmationDialog from './components/ConfirmationDialog';
 import ModernAgentsPage from './components/ModernAgentsPage'; // Importa la nuova pagina agenti
 import ModernSMRanking from './components/ModernSMRanking'; // Importa la nuova pagina classifica SM
 import ModernProductsAnalysis from './components/ModernProductsAnalysis'; // Importa la nuova pagina prodotti
+import ModernNewClientsPage from './components/ModernNewClientsPage'; // Importa la nuova pagina clienti
 import TestPage from './components/TestPage'; // Importa il componente TestPage
 import ModernDashboard from './components/ModernDashboard'; // Importa la nuova dashboard
 import ModernSidebar from './components/ModernSidebar';
@@ -616,7 +617,7 @@ const MainApp = ({ currentUser, onLogout, isAuthenticated }) => {
       case 'products':
         return <ModernProductsAnalysis />;
       case 'new-clients':
-        return <div className="section-placeholder">🆕 Nuovi Clienti - Disponibile dopo caricamento componenti avanzati</div>;
+        return <ModernNewClientsPage />;
       case 'fastweb':
         return <div className="section-placeholder">⚡ Contratti Fastweb - Disponibile dopo caricamento componenti avanzati</div>;
       case 'test':

--- a/src/components/ModernNewClientsPage.css
+++ b/src/components/ModernNewClientsPage.css
@@ -1,0 +1,801 @@
+/* ModernNewClientsPage.css */
+
+.modern-new-clients-container {
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  min-height: 100vh;
+  padding: 32px;
+}
+
+.modern-new-clients-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  color: #64748b;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #e2e8f0;
+  border-top: 3px solid #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 16px;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Page Header */
+.page-header {
+  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  border-radius: 24px;
+  padding: 40px;
+  margin-bottom: 32px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.header-text {
+  flex: 1;
+}
+
+.page-title {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin: 0 0 8px 0;
+}
+
+.page-subtitle {
+  font-size: 1.1rem;
+  color: #64748b;
+  margin: 0;
+}
+
+.refresh-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  color: white;
+  border: none;
+  border-radius: 16px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+.refresh-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(59, 130, 246, 0.4);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.refresh-btn.refreshing {
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+/* Header Stats */
+.header-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 24px;
+}
+
+.stat-card {
+  background: white;
+  border-radius: 20px;
+  padding: 28px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.stat-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: var(--accent-color, #3b82f6);
+}
+
+.stat-card.primary::before { background: linear-gradient(90deg, #3b82f6, #1d4ed8); }
+.stat-card.success::before { background: linear-gradient(90deg, #10b981, #047857); }
+.stat-card.accent::before { background: linear-gradient(90deg, #f59e0b, #d97706); }
+.stat-card.info::before { background: linear-gradient(90deg, #8b5cf6, #7c3aed); }
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.1);
+}
+
+.stat-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  flex-shrink: 0;
+}
+
+.stat-card.primary .stat-icon { background: linear-gradient(135deg, #3b82f6, #1d4ed8); }
+.stat-card.success .stat-icon { background: linear-gradient(135deg, #10b981, #047857); }
+.stat-card.accent .stat-icon { background: linear-gradient(135deg, #f59e0b, #d97706); }
+.stat-card.info .stat-icon { background: linear-gradient(135deg, #8b5cf6, #7c3aed); }
+
+.stat-content {
+  flex: 1;
+}
+
+.stat-value {
+  display: block;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1e293b;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.stat-label {
+  font-size: 0.95rem;
+  color: #64748b;
+  font-weight: 500;
+}
+
+.stat-trend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  font-size: 0.85rem;
+  color: #059669;
+  font-weight: 500;
+}
+
+/* Filters Section */
+.filters-modern {
+  background: white;
+  border-radius: 20px;
+  padding: 28px;
+  margin-bottom: 32px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.filters-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.filters-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.results-count {
+  color: #64748b;
+  font-size: 0.9rem;
+  background: #f1f5f9;
+  padding: 8px 16px;
+  border-radius: 20px;
+}
+
+.filters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  align-items: end;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+  color: #374151;
+  font-size: 0.9rem;
+}
+
+.modern-search-input,
+.modern-select {
+  padding: 12px 16px;
+  border: 2px solid #e5e7eb;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  background: white;
+  transition: all 0.2s ease;
+}
+
+.modern-search-input:focus,
+.modern-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
+}
+
+.sort-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.sort-controls .modern-select {
+  flex: 1;
+}
+
+.sort-order-btn {
+  padding: 12px;
+  border: 2px solid #e5e7eb;
+  border-radius: 12px;
+  background: white;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1.2rem;
+  transition: all 0.2s ease;
+}
+
+.sort-order-btn:hover {
+  border-color: #3b82f6;
+  color: #3b82f6;
+}
+
+.reset-filters-btn {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+  color: white;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.2);
+}
+
+.reset-filters-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(245, 158, 11, 0.3);
+}
+
+/* Top Performers Section */
+.top-performers-section {
+  margin-bottom: 32px;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin-bottom: 20px;
+}
+
+.performers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.performer-card {
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.performer-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.performer-card.rank-1 {
+  border-left: 4px solid #fbbf24;
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+}
+
+.performer-card.rank-2 {
+  border-left: 4px solid #94a3b8;
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+}
+
+.performer-card.rank-3 {
+  border-left: 4px solid #cd7c2f;
+  background: linear-gradient(135deg, #fdf4ff 0%, #fae8ff 100%);
+}
+
+.performer-rank {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+}
+
+.performer-card.rank-1 .performer-rank {
+  background: linear-gradient(135deg, #fbbf24, #f59e0b);
+}
+
+.performer-card.rank-2 .performer-rank {
+  background: linear-gradient(135deg, #94a3b8, #64748b);
+}
+
+.performer-card.rank-3 .performer-rank {
+  background: linear-gradient(135deg, #cd7c2f, #92400e);
+}
+
+.performer-info h4 {
+  margin: 0 0 4px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.performer-sm {
+  margin: 0 0 16px 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.performer-stats {
+  display: flex;
+  gap: 16px;
+}
+
+.performer-stats .stat-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: rgba(59, 130, 246, 0.1);
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.performer-stats .stat-item.primary {
+  background: rgba(16, 185, 129, 0.1);
+  color: #047857;
+}
+
+/* Agents Section */
+.agents-section {
+  margin-bottom: 32px;
+}
+
+.agents-grid-modern {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  gap: 24px;
+  transition: opacity 0.3s ease;
+}
+
+.no-results-modern {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 80px 40px;
+  background: white;
+  border-radius: 20px;
+  color: #64748b;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.no-results-icon {
+  margin: 0 auto 24px;
+  opacity: 0.5;
+}
+
+.no-results-modern h3 {
+  margin: 0 0 12px 0;
+  font-size: 1.5rem;
+  color: #1e293b;
+}
+
+.no-results-modern p {
+  margin: 0 0 24px 0;
+  font-size: 1rem;
+}
+
+/* New Client Agent Card */
+.new-client-card {
+  background: white;
+  border-radius: 20px;
+  overflow: hidden;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.new-client-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+.new-client-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: var(--performance-color);
+}
+
+.new-client-card.high::before {
+  background: linear-gradient(90deg, #10b981, #047857);
+}
+
+.new-client-card.medium::before {
+  background: linear-gradient(90deg, #f59e0b, #d97706);
+}
+
+.new-client-card.low::before {
+  background: linear-gradient(90deg, #ef4444, #dc2626);
+}
+
+/* Card Header */
+.new-client-card .card-header {
+  padding: 24px 24px 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+}
+
+.new-client-card .card-header.high {
+  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
+}
+
+.new-client-card .card-header.medium {
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+}
+
+.new-client-card .card-header.low {
+  background: linear-gradient(135deg, #fef2f2 0%, #fecaca 100%);
+}
+
+.new-client-card .avatar {
+  width: 50px;
+  height: 50px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: white;
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  flex-shrink: 0;
+}
+
+.new-client-card .agent-info {
+  flex: 1;
+}
+
+.new-client-card .agent-name {
+  margin: 0 0 4px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.new-client-card .agent-sm {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.performance-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 16px;
+  backdrop-filter: blur(8px);
+}
+
+.new-clients-count {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+/* Card Body */
+.new-client-card .card-body {
+  padding: 16px 24px 24px;
+}
+
+.new-client-card .stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.new-client-card .stat-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: #f8fafc;
+  border-radius: 12px;
+  border: 1px solid #e2e8f0;
+  transition: all 0.2s ease;
+}
+
+.new-client-card .stat-item:hover {
+  background: #f1f5f9;
+  transform: translateY(-2px);
+}
+
+.new-client-card .stat-item.highlight {
+  background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+  border-color: #3b82f6;
+}
+
+.new-client-card .stat-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #64748b;
+  color: white;
+  flex-shrink: 0;
+}
+
+.new-client-card .stat-item.highlight .stat-icon {
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+}
+
+.new-client-card .stat-content {
+  flex: 1;
+}
+
+.new-client-card .stat-label {
+  display: block;
+  font-size: 0.8rem;
+  color: #64748b;
+  margin-bottom: 2px;
+}
+
+.new-client-card .stat-value {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.new-client-card .stat-value.primary {
+  color: #1d4ed8;
+  font-size: 1.2rem;
+}
+
+/* Acquisition Channels */
+.acquisition-channels {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.acquisition-channels h5 {
+  margin: 0 0 12px 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.channels-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 12px;
+}
+
+.channel-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background: #f1f5f9;
+  border-radius: 8px;
+  font-size: 0.85rem;
+}
+
+.channel-name {
+  color: #64748b;
+}
+
+.channel-value {
+  font-weight: 600;
+  color: #1e293b;
+}
+
+/* Card Footer */
+.new-client-card .card-footer {
+  padding: 16px 24px 24px;
+  display: flex;
+  justify-content: center;
+}
+
+.performance-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: #f8fafc;
+  border-radius: 20px;
+  border: 1px solid #e2e8f0;
+}
+
+.indicator-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+.indicator-dot.high {
+  background: #10b981;
+}
+
+.indicator-dot.medium {
+  background: #f59e0b;
+}
+
+.indicator-dot.low {
+  background: #ef4444;
+}
+
+.performance-text {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #64748b;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .modern-new-clients-container {
+    padding: 20px 16px;
+  }
+
+  .page-header {
+    padding: 24px 20px;
+  }
+
+  .header-content {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+  }
+
+  .page-title {
+    font-size: 2rem;
+  }
+
+  .header-stats {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+  }
+
+  .stat-card {
+    padding: 20px;
+    flex-direction: column;
+    text-align: center;
+    gap: 12px;
+  }
+
+  .filters-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .performers-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .agents-grid-modern {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .new-client-card .stats-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .performer-stats {
+    flex-direction: column;
+    gap: 8px;
+  }
+}
+
+@media (max-width: 480px) {
+  .modern-new-clients-container {
+    padding: 16px 12px;
+  }
+
+  .page-header {
+    padding: 20px 16px;
+  }
+
+  .page-title {
+    font-size: 1.8rem;
+  }
+
+  .stat-card {
+    padding: 16px;
+  }
+
+  .filters-modern {
+    padding: 20px;
+  }
+
+  .new-client-card .card-header {
+    padding: 20px 16px 12px;
+  }
+
+  .new-client-card .card-body {
+    padding: 12px 16px 20px;
+  }
+}

--- a/src/components/ModernNewClientsPage.js
+++ b/src/components/ModernNewClientsPage.js
@@ -1,0 +1,238 @@
+import React, { useState, useMemo } from 'react';
+import { useData } from '../App';
+import { formatAgentName, formatCurrency, formatNumber } from '../utils/formatter';
+import './ModernNewClientsPage.css';
+import { UserPlus, RefreshCw, Search, Filter, Users, ArrowUp, ArrowDown, Award, Trophy, BarChart, DollarSign, Briefcase, Target, Building, Handshake, TrendingUp } from 'lucide-react';
+
+const getPerformanceLevel = (clientCount) => {
+    if (clientCount >= 5) return 'high';
+    if (clientCount >= 2) return 'medium';
+    return 'low';
+};
+
+const NewClientAgentCard = ({ agent }) => {
+    const performance = getPerformanceLevel(agent.nuovoCliente);
+    const avatarName = agent.nome.split(' ').map(n => n[0]).join('').substring(0, 2);
+
+    return (
+        <div className={`new-client-card ${performance}`}>
+            <div className={`card-header ${performance}`}>
+                <div className="avatar">{avatarName}</div>
+                <div className="agent-info">
+                    <h3 className="agent-name">{agent.nome}</h3>
+                    <p className="agent-sm">{agent.sm}</p>
+                </div>
+                <div className="performance-badge">
+                    <span className="new-clients-count">{formatNumber(agent.nuovoCliente)}</span>
+                    <UserPlus size={20} />
+                </div>
+            </div>
+            <div className="card-body">
+                <div className="stats-grid">
+                    <div className="stat-item highlight">
+                        <div className="stat-icon"><DollarSign size={20} /></div>
+                        <div className="stat-content">
+                            <span className="stat-label">Fatturato Nuovi Clienti</span>
+                            <span className="stat-value primary">{formatCurrency(agent.fatturatoNuovoCliente)}</span>
+                        </div>
+                    </div>
+                    <div className="stat-item">
+                        <div className="stat-icon"><TrendingUp size={20} /></div>
+                        <div className="stat-content">
+                            <span className="stat-label">Fatturato Rush</span>
+                            <span className="stat-value">{formatCurrency(agent.fatturatoRush)}</span>
+                        </div>
+                    </div>
+                </div>
+                {/* Placeholder for acquisition channels as data is not available */}
+                <div className="acquisition-channels">
+                    <h5>Canali Acquisizione</h5>
+                    <div className="channels-grid">
+                        <div className="channel-item">
+                            <span className="channel-name">Diretto</span>
+                            <span className="channel-value">-</span>
+                        </div>
+                        <div className="channel-item">
+                            <span className="channel-name">Referral</span>
+                            <span className="channel-value">-</span>
+                        </div>
+                         <div className="channel-item">
+                            <span className="channel-name">Altro</span>
+                            <span className="channel-value">-</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div className="card-footer">
+                <div className="performance-indicator">
+                    <div className={`indicator-dot ${performance}`}></div>
+                    <span className="performance-text">Performance: {performance.charAt(0).toUpperCase() + performance.slice(1)}</span>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+
+const PerformerCard = ({ agent, rank }) => {
+    const rankClass = `rank-${rank}`;
+    return (
+        <div className={`performer-card ${rankClass}`}>
+            <div className="performer-rank">{rank}</div>
+            <div className="performer-info">
+                <h4>{agent.nome}</h4>
+                <p className="performer-sm">{agent.sm}</p>
+            </div>
+            <div className="performer-stats">
+                <div className="stat-item">
+                    <UserPlus size={16} /> <strong>{formatNumber(agent.nuovoCliente)}</strong> Clienti
+                </div>
+                <div className="stat-item primary">
+                    <DollarSign size={16} /> <strong>{formatCurrency(agent.fatturatoNuovoCliente)}</strong> Fatturato
+                </div>
+            </div>
+        </div>
+    );
+};
+
+
+const ModernNewClientsPage = () => {
+    const { data, selectedFileDate, loadFiles, globalLoading } = useData();
+    const [refreshing, setRefreshing] = useState(false);
+    const [filters, setFilters] = useState({ searchTerm: '', selectedSm: '' });
+    const [sort, setSort] = useState({ by: 'nuovoCliente', order: 'desc' });
+
+    const { agents, smList, stats, topPerformers, allAgentsInPeriod } = useMemo(() => {
+        const emptyState = { agents: [], smList: [], stats: { totalClients: 0, totalRevenue: 0, avgClientsPerAgent: 0, topSm: { name: 'N/A', clients: 0 } }, topPerformers: [], allAgentsInPeriod: [] };
+        if (!selectedFileDate || !data.uploadedFiles || data.uploadedFiles.length === 0) return emptyState;
+
+        const file = data.uploadedFiles.find(f => f.date === selectedFileDate);
+        if (!file || !file.data || !file.data.agents) return emptyState;
+
+        const allAgents = file.data.agents.map((agent, index) => ({ ...agent, id: `${file.date}-${agent.nome}-${index}`, nome: formatAgentName(agent.nome) }));
+        const uniqueSmList = [...new Set(allAgents.map(a => a.sm).filter(Boolean))].sort();
+
+        let filteredAgents = allAgents.filter(agent =>
+            agent.nome.toLowerCase().includes(filters.searchTerm.toLowerCase()) &&
+            (filters.selectedSm === '' || agent.sm === filters.selectedSm)
+        );
+
+        filteredAgents.sort((a, b) => {
+            const valA = a[sort.by] || 0;
+            const valB = b[sort.by] || 0;
+            return sort.order === 'asc' ? valA - valB : valB - valA;
+        });
+
+        const totalClients = filteredAgents.reduce((sum, agent) => sum + (agent.nuovoCliente || 0), 0);
+        const totalRevenue = filteredAgents.reduce((sum, agent) => sum + (agent.fatturatoNuovoCliente || 0), 0);
+        const avgClientsPerAgent = filteredAgents.length > 0 ? totalClients / filteredAgents.length : 0;
+
+        const smPerformance = allAgents.reduce((acc, agent) => {
+            acc[agent.sm] = (acc[agent.sm] || 0) + (agent.nuovoCliente || 0);
+            return acc;
+        }, {});
+        const topSmEntry = Object.entries(smPerformance).sort((a, b) => b[1] - a[1])[0];
+        const topSm = topSmEntry ? { name: topSmEntry[0], clients: topSmEntry[1] } : { name: 'N/A', clients: 0 };
+
+        const topPerformers = [...allAgents].filter(a => a.nuovoCliente > 0).sort((a, b) => (b.nuovoCliente || 0) - (a.nuovoCliente || 0)).slice(0, 3);
+
+        return { agents: filteredAgents, smList: uniqueSmList, stats: { totalClients, totalRevenue, avgClientsPerAgent, topSm }, topPerformers, allAgentsInPeriod: allAgents };
+    }, [data.uploadedFiles, selectedFileDate, filters, sort]);
+
+    const handleFilterChange = (name, value) => setFilters(prev => ({ ...prev, [name]: value }));
+    const handleSortChange = (newSortBy) => setSort(prev => ({ ...prev, by: newSortBy, order: prev.by === newSortBy && prev.order === 'desc' ? 'asc' : 'desc' }));
+    const handleRefresh = async () => { setRefreshing(true); await loadFiles(); setRefreshing(false); };
+    const resetFilters = () => { setFilters({ searchTerm: '', selectedSm: '' }); setSort({ by: 'nuovoCliente', order: 'desc' }); };
+
+    if (globalLoading && !stats.totalClients) {
+        return <div className="modern-new-clients-loading"><div className="loading-spinner"></div><p>Analizzando i dati di acquisizione...</p></div>;
+    }
+    if (!selectedFileDate || !data.processedData[selectedFileDate]) {
+        return <div className="modern-new-clients-loading"><h3>Nessun file selezionato</h3><p>Per favore, vai alla sezione "Gestione File" e seleziona un periodo da analizzare.</p></div>;
+    }
+
+    return (
+        <div className="modern-new-clients-container">
+            <div className="page-header">
+                <div className="header-content">
+                    <div className="header-text">
+                        <h1 className="page-title"><UserPlus size={32} /> Acquisizione Nuovi Clienti</h1>
+                        <p className="page-subtitle">Analisi delle performance di acquisizione della rete vendita.</p>
+                    </div>
+                    <button className={`refresh-btn ${refreshing || globalLoading ? 'refreshing' : ''}`} onClick={handleRefresh} disabled={refreshing || globalLoading}>
+                        <RefreshCw size={20} /> {refreshing || globalLoading ? 'Aggiornamento...' : 'Aggiorna Dati'}
+                    </button>
+                </div>
+                <div className="header-stats">
+                    <div className="stat-card primary"><div className="stat-icon"><Handshake size={24} /></div><div className="stat-content"><span className="stat-value">{formatNumber(stats.totalClients)}</span><span className="stat-label">Clienti Acquisiti</span></div></div>
+                    <div className="stat-card success"><div className="stat-icon"><DollarSign size={24} /></div><div className="stat-content"><span className="stat-value">{formatCurrency(stats.totalRevenue)}</span><span className="stat-label">Fatturato da Nuovi Clienti</span></div></div>
+                    <div className="stat-card accent"><div className="stat-icon"><BarChart size={24} /></div><div className="stat-content"><span className="stat-value">{stats.avgClientsPerAgent.toFixed(1)}</span><span className="stat-label">Media Clienti / Agente</span></div></div>
+                    <div className="stat-card info"><div className="stat-icon"><Building size={24} /></div><div className="stat-content"><span className="stat-value">{stats.topSm.name}</span><span className="stat-label">Top Coordinatore ({formatNumber(stats.topSm.clients)} clienti)</span></div></div>
+                </div>
+            </div>
+
+            {topPerformers.length > 0 && (
+                <div className="top-performers-section">
+                    <h2 className="section-title"><Trophy size={24}/> Top Performers</h2>
+                    <div className="performers-grid">
+                        {topPerformers.map((agent, index) => <PerformerCard key={agent.id} agent={agent} rank={index + 1} />)}
+                    </div>
+                </div>
+            )}
+
+            <div className="filters-modern">
+                <div className="filters-header">
+                    <div className="filters-title"><Filter size={20} />Filtri Agenti</div>
+                    <div className="results-count">{agents.length} di {allAgentsInPeriod.length} agenti</div>
+                </div>
+                <div className="filters-grid">
+                    <div className="filter-group">
+                        <label className="filter-label"><Search size={16} /> Cerca Agente</label>
+                        <input type="text" placeholder="Nome agente..." value={filters.searchTerm} onChange={(e) => handleFilterChange('searchTerm', e.target.value)} className="modern-search-input" />
+                    </div>
+                    <div className="filter-group">
+                        <label className="filter-label"><Users size={16} /> Filtra per Coordinatore</label>
+                        <select value={filters.selectedSm} onChange={(e) => handleFilterChange('selectedSm', e.target.value)} className="modern-select">
+                            <option value="">Tutti i Coordinatori</option>
+                            {smList.map(sm => <option key={sm} value={sm}>{sm}</option>)}
+                        </select>
+                    </div>
+                    <div className="filter-group">
+                        <label className="filter-label">Ordina Per</label>
+                        <div className="sort-controls">
+                            <select value={sort.by} onChange={(e) => handleSortChange(e.target.value)} className="modern-select">
+                                <option value="nuovoCliente">Nuovi Clienti</option>
+                                <option value="fatturatoNuovoCliente">Fatturato NC</option>
+                                <option value="fatturatoRush">Fatturato Rush</option>
+                            </select>
+                            <button className="sort-order-btn" onClick={() => handleSortChange(sort.by)}>
+                                {sort.order === 'desc' ? <ArrowDown size={16} /> : <ArrowUp size={16} />}
+                            </button>
+                        </div>
+                    </div>
+                     <div className="filter-group">
+                        <label className="filter-label">&nbsp;</label>
+                        <button className="reset-filters-btn" onClick={resetFilters}>Reset Filtri</button>
+                    </div>
+                </div>
+            </div>
+
+            <div className="agents-section">
+                 <h2 className="section-title"><Briefcase size={24}/> Dettaglio Agenti</h2>
+                <div className={`agents-grid-modern ${globalLoading ? 'loading' : ''}`}>
+                    {agents.length > 0 ? (
+                        agents.map(agent => <NewClientAgentCard key={agent.id} agent={agent} />)
+                    ) : (
+                        <div className="no-results-modern">
+                            <div className="no-results-icon"><Search size={48} /></div>
+                            <h3>Nessun agente trovato</h3>
+                            <p>Prova a modificare i filtri per visualizzare più risultati.</p>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ModernNewClientsPage;


### PR DESCRIPTION
This commit introduces a new "Nuovi Clienti" (New Clients) page to the application, replacing the previous placeholder.

The new page includes:
- A dedicated component `ModernNewClientsPage.js` with its own stylesheet `ModernNewClientsPage.css` as per project conventions.
- A detailed view with statistics on new client acquisition, including total clients, total revenue from new clients, and average clients per agent.
- A "Top Performers" section highlighting the agents with the most new clients.
- Filtering and sorting capabilities to allow users to analyze the data by agent name, sales manager, and various metrics.
- A grid of agent cards, each providing a summary of the agent's performance in acquiring new clients.

The component is fully integrated into the main application and uses the existing `useData` hook to fetch and process live data, with no mock data used.