### PR TITLE
feat: create ModernFastwebPage and integrate into app

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ import ModernAgentsPage from './components/ModernAgentsPage'; // Importa la nuov
 import ModernSMRanking from './components/ModernSMRanking'; // Importa la nuova pagina classifica SM
 import ModernProductsAnalysis from './components/ModernProductsAnalysis'; // Importa la nuova pagina prodotti
 import ModernNewClientsPage from './components/ModernNewClientsPage'; // Importa la nuova pagina clienti
+import ModernFastwebPage from './components/ModernFastwebPage'; // Importa la nuova pagina Fastweb
 import TestPage from './components/TestPage'; // Importa il componente TestPage
 import ModernDashboard from './components/ModernDashboard'; // Importa la nuova dashboard
 import ModernSidebar from './components/ModernSidebar';
@@ -619,7 +620,7 @@ const MainApp = ({ currentUser, onLogout, isAuthenticated }) => {
       case 'new-clients':
         return <ModernNewClientsPage />;
       case 'fastweb':
-        return <div className="section-placeholder">⚡ Contratti Fastweb - Disponibile dopo caricamento componenti avanzati</div>;
+        return <ModernFastwebPage />;
       case 'test':
         return <TestPage />;
       default:

--- a/src/components/ModernFastwebPage.css
+++ b/src/components/ModernFastwebPage.css
@@ -1,0 +1,967 @@
+/* ModernFastwebPage.css */
+
+.modern-fastweb-container {
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  min-height: 100vh;
+  padding: 32px;
+}
+
+.modern-fastweb-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  color: #64748b;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid #e2e8f0;
+  border-top: 3px solid #f97316;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 16px;
+}
+
+/* Page Header with Fastweb Theme */
+.page-header.fastweb-theme {
+  background: linear-gradient(135deg, #fff7ed 0%, #fed7aa 100%);
+  border-radius: 24px;
+  padding: 40px;
+  margin-bottom: 32px;
+  box-shadow: 0 10px 30px rgba(249, 115, 22, 0.08);
+  border: 1px solid rgba(249, 115, 22, 0.1);
+  position: relative;
+  overflow: hidden;
+}
+
+.page-header.fastweb-theme::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #f97316, #ea580c);
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.header-text {
+  flex: 1;
+}
+
+.page-title {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin: 0 0 8px 0;
+}
+
+.page-title svg {
+  color: #f97316;
+}
+
+.page-subtitle {
+  font-size: 1.1rem;
+  color: #64748b;
+  margin: 0;
+}
+
+.header-actions {
+  display: flex;
+  gap: 16px;
+}
+
+.refresh-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 24px;
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  color: white;
+  border: none;
+  border-radius: 16px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 12px rgba(249, 115, 22, 0.3);
+}
+
+.refresh-btn:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 20px rgba(249, 115, 22, 0.4);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.refresh-btn.refreshing {
+  animation: pulse 2s infinite;
+}
+
+/* KPI Grid */
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 24px;
+}
+
+.kpi-card {
+  background: white;
+  border-radius: 20px;
+  padding: 28px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  transition: all 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.kpi-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: var(--accent-color);
+}
+
+.kpi-card.primary::before { background: linear-gradient(90deg, #f97316, #ea580c); }
+.kpi-card.success::before { background: linear-gradient(90deg, #10b981, #047857); }
+.kpi-card.accent::before { background: linear-gradient(90deg, #8b5cf6, #7c3aed); }
+.kpi-card.info::before { background: linear-gradient(90deg, #3b82f6, #1d4ed8); }
+
+.kpi-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.1);
+}
+
+.kpi-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  flex-shrink: 0;
+}
+
+.kpi-card.primary .kpi-icon { background: linear-gradient(135deg, #f97316, #ea580c); }
+.kpi-card.success .kpi-icon { background: linear-gradient(135deg, #10b981, #047857); }
+.kpi-card.accent .kpi-icon { background: linear-gradient(135deg, #8b5cf6, #7c3aed); }
+.kpi-card.info .kpi-icon { background: linear-gradient(135deg, #3b82f6, #1d4ed8); }
+
+.kpi-content {
+  flex: 1;
+}
+
+.kpi-value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #1e293b;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.kpi-label {
+  font-size: 0.95rem;
+  color: #64748b;
+  font-weight: 500;
+  margin-bottom: 8px;
+}
+
+.kpi-trend {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: #059669;
+  font-weight: 500;
+}
+
+.kpi-trend.positive {
+  color: #059669;
+}
+
+.kpi-trend.negative {
+  color: #dc2626;
+}
+
+.kpi-meta {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  margin-top: 4px;
+}
+
+/* View Navigation Tabs */
+.view-tabs {
+  display: flex;
+  background: white;
+  border-radius: 16px;
+  padding: 8px;
+  margin-bottom: 32px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.tab-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  background: none;
+  border: none;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 500;
+  color: #64748b;
+  transition: all 0.2s ease;
+  flex: 1;
+  justify-content: center;
+}
+
+.tab-btn:hover {
+  background: #f8fafc;
+  color: #1e293b;
+}
+
+.tab-btn.active {
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  color: white;
+  box-shadow: 0 4px 12px rgba(249, 115, 22, 0.2);
+}
+
+/* Overview Section */
+.overview-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  gap: 32px;
+}
+
+.section-card {
+  background: white;
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.section-header h3 {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin: 0;
+}
+
+.badge-live {
+  background: linear-gradient(135deg, #10b981, #047857);
+  color: white;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  animation: pulse 2s infinite;
+}
+
+/* Top Performers List */
+.performers-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.performer-item {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px;
+  background: #f8fafc;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  transition: all 0.3s ease;
+}
+
+.performer-item:hover {
+  background: #f1f5f9;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.performer-item.rank-1 {
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+  border-color: #f59e0b;
+}
+
+.performer-item.rank-2 {
+  background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+  border-color: #94a3b8;
+}
+
+.performer-item.rank-3 {
+  background: linear-gradient(135deg, #fdf4ff 0%, #fae8ff 100%);
+  border-color: #a855f7;
+}
+
+.performer-rank {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.performer-item.rank-1 .performer-rank {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+}
+
+.performer-item.rank-2 .performer-rank {
+  background: linear-gradient(135deg, #94a3b8, #64748b);
+}
+
+.performer-item.rank-3 .performer-rank {
+  background: linear-gradient(135deg, #a855f7, #7c3aed);
+}
+
+.performer-info {
+  flex: 1;
+}
+
+.performer-info h4 {
+  margin: 0 0 4px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.performer-info p {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.performer-stats {
+  display: flex;
+  gap: 16px;
+}
+
+.performer-stats .stat-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: rgba(59, 130, 246, 0.1);
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.performer-stats .stat-item.primary {
+  background: rgba(249, 115, 22, 0.1);
+  color: #ea580c;
+}
+
+/* SM Rankings Grid */
+.sm-rankings-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 16px;
+}
+
+.sm-card {
+  background: #f8fafc;
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid #e2e8f0;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.sm-card:hover {
+  background: #f1f5f9;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.sm-card.rank-1 {
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+  border-color: #f59e0b;
+}
+
+.sm-rank {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.8rem;
+  box-shadow: 0 2px 8px rgba(59, 130, 246, 0.3);
+}
+
+.sm-card.rank-1 .sm-rank {
+  background: linear-gradient(135deg, #f59e0b, #d97706);
+}
+
+.sm-info h4 {
+  margin: 0 0 16px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.sm-metrics {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sm-metrics .metric {
+  text-align: center;
+}
+
+.metric-value {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.metric-label {
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-top: 2px;
+}
+
+.results-count {
+  background: #f1f5f9;
+  color: #64748b;
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+}
+
+/* Agents Section */
+.agents-section {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.filters-card {
+  background: white;
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+}
+
+.filters-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.filters-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.filters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  align-items: end;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.filter-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+  color: #374151;
+  font-size: 0.9rem;
+}
+
+.filter-input,
+.filter-select {
+  padding: 12px 16px;
+  border: 2px solid #e5e7eb;
+  border-radius: 12px;
+  font-size: 0.95rem;
+  background: white;
+  transition: all 0.2s ease;
+}
+
+.filter-input:focus,
+.filter-select:focus {
+  outline: none;
+  border-color: #f97316;
+  box-shadow: 0 0 0 4px rgba(249, 115, 22, 0.1);
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: #f97316;
+}
+
+/* Agents Grid */
+.agents-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.no-results {
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 80px 40px;
+  background: white;
+  border-radius: 20px;
+  color: #64748b;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.no-results svg {
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+
+.no-results h3 {
+  margin: 0 0 8px 0;
+  color: #1e293b;
+}
+
+.no-results p {
+  margin: 0;
+}
+
+/* Fastweb Agent Card */
+.fastweb-agent-card {
+  background: white;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  transition: all 0.3s ease;
+}
+
+.fastweb-agent-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.fastweb-agent-card.high {
+  border-left: 4px solid #10b981;
+}
+
+.fastweb-agent-card.medium {
+  border-left: 4px solid #f59e0b;
+}
+
+.fastweb-agent-card.low {
+  border-left: 4px solid #f97316;
+}
+
+.fastweb-agent-card.none {
+  border-left: 4px solid #e5e7eb;
+  opacity: 0.7;
+}
+
+.fastweb-agent-card .card-header {
+  padding: 20px;
+  background: #f8fafc;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.fastweb-agent-card.high .card-header {
+  background: linear-gradient(135deg, #ecfdf5 0%, #d1fae5 100%);
+}
+
+.fastweb-agent-card.medium .card-header {
+  background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%);
+}
+
+.fastweb-agent-card.low .card-header {
+  background: linear-gradient(135deg, #fff7ed 0%, #fed7aa 100%);
+}
+
+.agent-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.agent-info {
+  flex: 1;
+}
+
+.agent-info h4 {
+  margin: 0 0 4px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.agent-info p {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.contracts-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(249, 115, 22, 0.1);
+  color: #ea580c;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.card-metrics {
+  padding: 16px 20px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.metric-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.metric-icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: #64748b;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.metric-content {
+  flex: 1;
+}
+
+.metric-content .metric-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #64748b;
+  margin-bottom: 2px;
+}
+
+.metric-content .metric-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.card-footer {
+  padding: 16px 20px;
+  border-top: 1px solid #e2e8f0;
+  display: flex;
+  justify-content: center;
+}
+
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.status-indicator.high {
+  background: rgba(16, 185, 129, 0.1);
+  color: #047857;
+}
+
+.status-indicator.medium {
+  background: rgba(245, 158, 11, 0.1);
+  color: #d97706;
+}
+
+.status-indicator.low {
+  background: rgba(249, 115, 22, 0.1);
+  color: #ea580c;
+}
+
+.status-indicator.none {
+  background: rgba(156, 163, 175, 0.1);
+  color: #6b7280;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+.status-indicator.high .status-dot {
+  background: #10b981;
+}
+
+.status-indicator.medium .status-dot {
+  background: #f59e0b;
+}
+
+.status-indicator.low .status-dot {
+  background: #f97316;
+}
+
+.status-indicator.none .status-dot {
+  background: #9ca3af;
+}
+
+/* Insights Section */
+.insights-section {
+  padding: 20px 0;
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 24px;
+}
+
+.insight-card {
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
+  display: flex;
+  gap: 16px;
+  transition: all 0.3s ease;
+}
+
+.insight-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+}
+
+.insight-card.success {
+  border-left: 4px solid #10b981;
+}
+
+.insight-card.warning {
+  border-left: 4px solid #f59e0b;
+}
+
+.insight-card.info {
+  border-left: 4px solid #3b82f6;
+}
+
+.insight-icon {
+  flex-shrink: 0;
+}
+
+.insight-card.success .insight-icon {
+  color: #10b981;
+}
+
+.insight-card.warning .insight-icon {
+  color: #f59e0b;
+}
+
+.insight-card.info .insight-icon {
+  color: #3b82f6;
+}
+
+.insight-content h4 {
+  margin: 0 0 8px 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.insight-content p {
+  margin: 0 0 12px 0;
+  color: #64748b;
+  line-height: 1.5;
+}
+
+.insight-action {
+  font-size: 0.85rem;
+  color: #374151;
+  background: #f8fafc;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border-left: 3px solid #3b82f6;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .modern-fastweb-container {
+    padding: 20px 16px;
+  }
+
+  .page-header.fastweb-theme {
+    padding: 24px 20px;
+  }
+
+  .header-content {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+  }
+
+  .page-title {
+    font-size: 2rem;
+  }
+
+  .kpi-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+  }
+
+  .kpi-card {
+    padding: 20px;
+    flex-direction: column;
+    text-align: center;
+    gap: 12px;
+  }
+
+  .overview-section {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .section-card {
+    padding: 24px 20px;
+  }
+
+  .performer-stats {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .sm-rankings-grid {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .filters-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .agents-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .card-metrics {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+
+  .insights-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .modern-fastweb-container {
+    padding: 16px 12px;
+  }
+
+  .page-header.fastweb-theme {
+    padding: 20px 16px;
+  }
+
+  .page-title {
+    font-size: 1.8rem;
+  }
+
+  .view-tabs {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .tab-btn {
+    justify-content: flex-start;
+  }
+}

--- a/src/components/ModernFastwebPage.js
+++ b/src/components/ModernFastwebPage.js
@@ -1,0 +1,288 @@
+import React, { useState, useMemo } from 'react';
+import { useData } from '../App';
+import './ModernFastwebPage.css';
+import { formatAgentName } from '../utils/formatter';
+import {
+  Zap,
+  Users,
+  Award,
+  TrendingUp,
+  BarChart,
+  Filter,
+  Search,
+  User,
+  FileText,
+  Star,
+  Shield,
+  Frown,
+  RefreshCw,
+  Eye,
+  UserCheck,
+  Building,
+  Crown
+} from 'lucide-react';
+
+// Helper to format numbers
+const formatNumber = (value) => {
+  return new Intl.NumberFormat('it-IT').format(value || 0);
+};
+
+const ModernFastwebPage = () => {
+  const { data, selectedFileDate, globalLoading, loadFiles } = useData();
+  const [activeView, setActiveView] = useState('overview');
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    await loadFiles();
+    // A little delay to give a feeling of loading
+    setTimeout(() => setIsRefreshing(false), 500);
+  };
+
+  const fastwebData = useMemo(() => {
+    if (!data.uploadedFiles || data.uploadedFiles.length === 0) {
+      return null;
+    }
+
+    const file = selectedFileDate
+      ? data.uploadedFiles.find(f => f.date === selectedFileDate)
+      : data.uploadedFiles[0];
+
+    if (!file?.data?.agents) {
+      return null;
+    }
+
+    const agents = file.data.agents;
+    const agentsWithFastweb = agents.filter(a => (a.fastwebEnergia || 0) > 0);
+
+    if (agentsWithFastweb.length === 0) {
+      return {
+        totalContracts: 0,
+        totalAgents: 0,
+        avgContracts: 0,
+        topAgent: null,
+        topSm: null,
+        agents: [],
+        smRanking: [],
+        period: file.displayDate
+      };
+    }
+
+    const totalContracts = agentsWithFastweb.reduce((sum, agent) => sum + agent.fastwebEnergia, 0);
+
+    const topAgent = agentsWithFastweb.reduce((max, agent) =>
+        agent.fastwebEnergia > max.fastwebEnergia ? agent : max, agentsWithFastweb[0]
+    );
+
+    // SM Ranking
+    const smMap = new Map();
+    agentsWithFastweb.forEach(agent => {
+      if (!agent.sm) return;
+      const smName = formatAgentName(agent.sm);
+      const current = smMap.get(smName) || { contracts: 0, agents: 0, agentList: [] };
+      current.contracts += agent.fastwebEnergia;
+      current.agents += 1;
+      current.agentList.push({ name: formatAgentName(agent.nome), contracts: agent.fastwebEnergia });
+      smMap.set(smName, current);
+    });
+
+    const smRanking = Array.from(smMap.entries())
+      .map(([name, data]) => ({ name, ...data }))
+      .sort((a, b) => b.contracts - a.contracts);
+
+    const topSm = smRanking.length > 0 ? smRanking[0] : null;
+
+    return {
+      totalContracts,
+      totalAgents: agentsWithFastweb.length,
+      avgContracts: totalContracts / agentsWithFastweb.length,
+      topAgent,
+      topSm,
+      agents: agentsWithFastweb.sort((a,b) => b.fastwebEnergia - a.fastwebEnergia),
+      smRanking,
+      period: file.displayDate
+    };
+  }, [data, selectedFileDate]);
+
+  if (globalLoading) {
+    return (
+      <div className="modern-fastweb-loading">
+        <div className="loading-spinner"></div>
+        <p>Caricamento dati Fastweb...</p>
+      </div>
+    );
+  }
+
+  if (!fastwebData) {
+    return (
+        <div className="modern-fastweb-container">
+            <div className="no-results" style={{ gridColumn: '1 / -1' }}>
+                <Frown size={64} />
+                <h3>Nessun dato Fastweb disponibile</h3>
+                <p>Carica un file per visualizzare le statistiche dei contratti Fastweb.</p>
+            </div>
+        </div>
+    );
+  }
+
+  const { totalContracts, totalAgents, avgContracts, topAgent, topSm, agents, smRanking, period } = fastwebData;
+
+  const renderOverview = () => (
+    <div className="overview-section">
+        <div className="section-card">
+            <div className="section-header">
+                <h3><Crown size={20} /> Top Performers</h3>
+                <span className="badge-live">Live</span>
+            </div>
+            <div className="performers-list">
+                {topAgent ? (
+                    <div className="performer-item rank-1">
+                        <div className="performer-rank">1</div>
+                        <div className="performer-info">
+                            <h4>{formatAgentName(topAgent.nome)}</h4>
+                            <p>Miglior Agente</p>
+                        </div>
+                        <div className="performer-stats">
+                            <div className="stat-item primary">
+                                <Zap size={14} />
+                                <strong>{formatNumber(topAgent.fastwebEnergia)}</strong> contratti
+                            </div>
+                        </div>
+                    </div>
+                ) : <p>Nessun agente con contratti Fastweb.</p>}
+
+                {topSm ? (
+                    <div className="performer-item rank-2">
+                        <div className="performer-rank">1</div>
+                        <div className="performer-info">
+                            <h4>{topSm.name}</h4>
+                            <p>Miglior SM</p>
+                        </div>
+                         <div className="performer-stats">
+                            <div className="stat-item primary">
+                                <Zap size={14} />
+                                <strong>{formatNumber(topSm.contracts)}</strong> contratti
+                            </div>
+                        </div>
+                    </div>
+                ) : <p>Nessun SM con contratti Fastweb.</p>}
+            </div>
+        </div>
+        <div className="section-card">
+            <div className="section-header">
+                <h3><Building size={20} /> Classifica Sales Manager</h3>
+            </div>
+            <div className="sm-rankings-grid">
+                {smRanking.slice(0, 4).map((sm, index) => (
+                    <div key={sm.name} className={`sm-card ${index === 0 ? 'rank-1' : ''}`}>
+                        {index === 0 && <div className="sm-rank">🏆</div>}
+                        <div className="sm-info">
+                            <h4>{sm.name}</h4>
+                        </div>
+                        <div className="sm-metrics">
+                            <div className="metric">
+                                <span className="metric-value">{formatNumber(sm.contracts)}</span>
+                                <span className="metric-label">Contratti</span>
+                            </div>
+                            <div className="metric">
+                                <span className="metric-value">{formatNumber(sm.agents)}</span>
+                                <span className="metric-label">Agenti</span>
+                            </div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    </div>
+  );
+
+  const renderAgentsList = () => (
+     <div className="agents-section">
+        <div className="agents-grid">
+            {agents.length > 0 ? agents.map(agent => (
+                <div key={agent.id} className="fastweb-agent-card low">
+                    <div className="card-header">
+                        <div className="agent-avatar">{formatAgentName(agent.nome).charAt(0)}</div>
+                        <div className="agent-info">
+                            <h4>{formatAgentName(agent.nome)}</h4>
+                            <p>{formatAgentName(agent.sm)}</p>
+                        </div>
+                        <div className="contracts-badge">
+                            <Zap size={16} />
+                            <span>{formatNumber(agent.fastwebEnergia)}</span>
+                        </div>
+                    </div>
+                </div>
+            )) : (
+                 <div className="no-results">
+                    <Frown size={48} />
+                    <h3>Nessun agente trovato</h3>
+                    <p>Nessun agente ha contratti Fastweb in questo periodo.</p>
+                </div>
+            )}
+        </div>
+     </div>
+  );
+
+  return (
+    <div className="modern-fastweb-container">
+      <header className="page-header fastweb-theme">
+        <div className="header-content">
+          <div className="header-text">
+            <h1 className="page-title"><Zap /> Analisi Fastweb</h1>
+            <p className="page-subtitle">Dettaglio e performance dei contratti Fastweb Energia per il periodo: <strong>{period || 'N/A'}</strong></p>
+          </div>
+          <div className="header-actions">
+            <button onClick={handleRefresh} disabled={isRefreshing} className={`refresh-btn ${isRefreshing ? 'refreshing' : ''}`}>
+              <RefreshCw size={18} />
+              <span>{isRefreshing ? 'Aggiornando...' : 'Aggiorna Dati'}</span>
+            </button>
+          </div>
+        </div>
+        <div className="kpi-grid">
+            <div className="kpi-card primary">
+                <div className="kpi-icon"><Zap size={28}/></div>
+                <div className="kpi-content">
+                    <div className="kpi-value">{formatNumber(totalContracts)}</div>
+                    <div className="kpi-label">Contratti Totali</div>
+                </div>
+            </div>
+            <div className="kpi-card success">
+                <div className="kpi-icon"><Users size={28}/></div>
+                <div className="kpi-content">
+                    <div className="kpi-value">{formatNumber(totalAgents)}</div>
+                    <div className="kpi-label">Agenti con Contratti</div>
+                </div>
+            </div>
+            <div className="kpi-card accent">
+                <div className="kpi-icon"><BarChart size={28}/></div>
+                <div className="kpi-content">
+                    <div className="kpi-value">{formatNumber(avgContracts.toFixed(2))}</div>
+                    <div className="kpi-label">Media Contratti/Agente</div>
+                </div>
+            </div>
+            <div className="kpi-card info">
+                <div className="kpi-icon"><Award size={28}/></div>
+                <div className="kpi-content">
+                    <div className="kpi-value">{topAgent ? formatAgentName(topAgent.nome) : 'N/A'}</div>
+                    <div className="kpi-label">Top Performer</div>
+                </div>
+            </div>
+        </div>
+      </header>
+
+      <div className="view-tabs">
+        <button className={`tab-btn ${activeView === 'overview' ? 'active' : ''}`} onClick={() => setActiveView('overview')}>
+          <Eye size={18} /> Overview
+        </button>
+        <button className={`tab-btn ${activeView === 'agents' ? 'active' : ''}`} onClick={() => setActiveView('agents')}>
+          <UserCheck size={18} /> Lista Agenti
+        </button>
+      </div>
+
+      {activeView === 'overview' ? renderOverview() : renderAgentsList()}
+    </div>
+  );
+};
+
+export default ModernFastwebPage;


### PR DESCRIPTION
This commit introduces the new 'Fastweb' section, replacing the previous placeholder.

- Creates the `ModernFastwebPage.js` component to display statistics and data related to Fastweb contracts.
- Adds a corresponding `ModernFastwebPage.css` file to style the new component, following the project's convention of separating styles.
- The new component is data-driven, using the existing `useData` hook to fetch and process real data, with no mock data included.
- Integrates the component into `App.js` by updating the routing to render `ModernFastwebPage` when the 'fastweb' section is selected.