### PR TITLE
fix: Correct icon color for Historical Analysis sidebar item

### DIFF
--- a/src/components/ModernSidebar.js
+++ b/src/components/ModernSidebar.js
@@ -15,7 +15,7 @@ const ModernSidebar = ({
     { id: 'products', label: 'Prodotti', icon: Package, color: 'from-purple-500 to-purple-600', description: 'Analisi prodotti' },
     { id: 'new-clients', label: 'Nuovi Clienti', icon: UserPlus, color: 'from-pink-500 to-pink-600', description: 'Dashboard clienti' },
     { id: 'fastweb', label: 'Fastweb', icon: Zap, color: 'from-orange-500 to-orange-600', description: 'Contratti Fastweb' },
-    { id: 'historical-analysis', label: 'Analisi Storia', icon: History, color: 'from-teal-500 to-teal-600', description: 'Analisi storica dei dati' },
+    { id: 'historical-analysis', label: 'Analisi Storia', icon: History, color: 'from-purple-500 to-purple-600', description: 'Analisi storica dei dati' },
     { id: 'files', label: 'Gestione File', icon: Upload, color: 'from-indigo-500 to-indigo-600', description: 'Upload e gestione' }
   ];
 


### PR DESCRIPTION
The icon for the 'Analisi Storia' item in the sidebar was not visible because the chosen background color ('teal') did not contrast with the white icon.

This commit changes the background color to a known working color ('purple') to ensure the icon is visible.