### PR TITLE
feat: Add user management page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import ModernProductsAnalysis from './components/ModernProductsAnalysis'; // Imp
 import ModernNewClientsPage from './components/ModernNewClientsPage'; // Importa la nuova pagina clienti
 import ModernFastwebPage from './components/ModernFastwebPage'; // Importa la nuova pagina Fastweb
 import ModernHistoricalAnalysis from './components/ModernHistoricalAnalysis'; // Importa la pagina Analisi Storica
+import ModernSettingsPage from './components/ModernSettingsPage'; // Importa la pagina Impostazioni
 import TestPage from './components/TestPage'; // Importa il componente TestPage
 import ModernDashboard from './components/ModernDashboard'; // Importa la nuova dashboard
 import ModernSidebar from './components/ModernSidebar';
@@ -624,6 +625,8 @@ const MainApp = ({ currentUser, onLogout, isAuthenticated }) => {
         return <ModernFastwebPage />;
       case 'historical-analysis':
         return <ModernHistoricalAnalysis setActiveSection={setActiveSection} />;
+      case 'settings':
+        return <ModernSettingsPage />;
       case 'test':
         return <TestPage />;
       default:

--- a/src/components/ModernSettingsPage.css
+++ b/src/components/ModernSettingsPage.css
@@ -1,0 +1,152 @@
+/* Styles for ModernSettingsPage component */
+.modern-settings-container {
+    padding: 2rem;
+    animation: fadeIn 0.5s ease-in-out;
+}
+
+.settings-content {
+    margin-top: 2rem;
+    background-color: var(--card-bg-color);
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.user-list-container {
+    overflow-x: auto;
+}
+
+.user-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+}
+
+.user-table th, .user-table td {
+    padding: 12px 15px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.user-table th {
+    background-color: var(--table-header-bg);
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 12px;
+    color: var(--text-secondary-color);
+}
+
+.user-table tbody tr:hover {
+    background-color: var(--table-hover-bg);
+}
+
+.role-badge {
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
+    text-transform: capitalize;
+}
+
+.role-badge.admin {
+    background-color: rgba(255, 165, 0, 0.2);
+    color: orange;
+}
+
+.role-badge.viewer {
+    background-color: rgba(0, 0, 255, 0.2);
+    color: blue;
+}
+
+.actions-cell {
+    display: flex;
+    gap: 10px;
+}
+
+.action-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary-color);
+    transition: color 0.2s;
+}
+
+.action-btn:hover {
+    color: var(--primary-color);
+}
+
+/* Modal Styles */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: var(--card-bg-color);
+    padding: 2rem;
+    border-radius: 12px;
+    width: 90%;
+    max-width: 500px;
+    position: relative;
+}
+
+.modal-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-secondary-color);
+}
+
+.form-group {
+    margin-bottom: 1rem;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.form-group input, .form-group select {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: var(--input-bg-color);
+    color: var(--text-primary-color);
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 2rem;
+}
+
+.btn {
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.btn-primary {
+    background: var(--primary-color);
+    color: white;
+}
+
+.btn-secondary {
+    background: var(--secondary-btn-bg);
+    color: var(--text-primary-color);
+}

--- a/src/components/ModernSettingsPage.js
+++ b/src/components/ModernSettingsPage.js
@@ -1,0 +1,195 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { apiService } from '../services/apiService';
+import './ModernSettingsPage.css';
+import { Shield, KeyRound, Edit, Trash, UserPlus, X, RefreshCw } from 'lucide-react';
+import toast from 'react-hot-toast';
+import ConfirmationDialog from './ConfirmationDialog'; // Assumendo che esista un ConfirmationDialog
+
+const UserModal = ({ user, onClose, onSave, isPasswordModal }) => {
+    const [role, setRole] = useState(user?.role);
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+
+    const handleSave = async () => {
+        if (isPasswordModal) {
+            if (password !== confirmPassword || !password) {
+                toast.error('Le password non coincidono o sono vuote.');
+                return;
+            }
+            onSave(user.id, { password });
+        } else {
+            onSave(user.id, { role });
+        }
+    };
+
+    return (
+        <div className="modal-overlay">
+            <div className="modal-content">
+                <button className="modal-close" onClick={onClose}><X size={24} /></button>
+                <h2>{isPasswordModal ? `Modifica Password per ${user.username}` : `Modifica Ruolo per ${user.username}`}</h2>
+
+                {isPasswordModal ? (
+                    <>
+                        <div className="form-group">
+                            <label>Nuova Password</label>
+                            <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+                        </div>
+                        <div className="form-group">
+                            <label>Conferma Nuova Password</label>
+                            <input type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
+                        </div>
+                    </>
+                ) : (
+                    <div className="form-group">
+                        <label>Ruolo</label>
+                        <select value={role} onChange={(e) => setRole(e.target.value)}>
+                            <option value="admin">Admin</option>
+                            <option value="viewer">Viewer</option>
+                        </select>
+                    </div>
+                )}
+
+                <div className="modal-actions">
+                    <button onClick={onClose} className="btn btn-secondary">Annulla</button>
+                    <button onClick={handleSave} className="btn btn-primary">Salva</button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+
+const ModernSettingsPage = () => {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedUser, setSelectedUser] = useState(null);
+  const [isPasswordModalOpen, setPasswordModalOpen] = useState(false);
+  const [isRoleModalOpen, setRoleModalOpen] = useState(false);
+
+  const fetchUsers = useCallback(async () => {
+      try {
+        setLoading(true);
+        const fetchedUsers = await apiService.getUsers();
+        setUsers(fetchedUsers);
+        setError(null);
+      } catch (err) {
+        setError('Impossibile caricare gli utenti.');
+        toast.error('Impossibile caricare gli utenti.');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+  }, []);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  const openModal = (user, type) => {
+      setSelectedUser(user);
+      if (type === 'password') {
+          setPasswordModalOpen(true);
+      } else {
+          setRoleModalOpen(true);
+      }
+  };
+
+  const closeModal = () => {
+      setSelectedUser(null);
+      setPasswordModalOpen(false);
+      setRoleModalOpen(false);
+  };
+
+  const handleUpdateRole = async (userId, { role }) => {
+    toast.loading('Aggiornamento ruolo...', { id: 'role-update' });
+    try {
+        await apiService.updateUserRole(userId, role);
+        toast.success('Ruolo aggiornato con successo!', { id: 'role-update' });
+        fetchUsers(); // Refresh user list
+        closeModal();
+    } catch (error) {
+        toast.error(`Errore: ${error.message}`, { id: 'role-update' });
+    }
+  };
+
+  const handleUpdatePassword = async (userId, { password }) => {
+    toast.loading('Aggiornamento password...', { id: 'password-update' });
+    try {
+        await apiService.adminUpdateUserPassword(userId, password);
+        toast.success('Password aggiornata con successo!', { id: 'password-update' });
+        closeModal();
+    } catch (error) {
+        toast.error(`Errore: ${error.message}`, { id: 'password-update' });
+    }
+  };
+
+  return (
+    <div className="modern-settings-container">
+      <div className="page-header">
+        <div className="header-content">
+          <div className="header-text">
+            <h1 className="page-title"><Shield size={32} /> Gestione Utenti</h1>
+            <p className="page-subtitle">Modifica ruoli e password degli utenti del sistema</p>
+          </div>
+          <button className={`refresh-btn ${loading ? 'refreshing' : ''}`} onClick={fetchUsers} disabled={loading}>
+            <RefreshCw size={20} />
+            {loading ? 'Aggiornamento...' : 'Aggiorna'}
+          </button>
+        </div>
+      </div>
+
+      <div className="settings-content">
+        <div className="user-list-container">
+            {loading && <p>Caricamento utenti...</p>}
+            {error && <p className="error-message">{error}</p>}
+            {!loading && !error && (
+                <table className="user-table">
+                    <thead>
+                        <tr>
+                            <th>Username</th>
+                            <th>Nome Completo</th>
+                            <th>Ruolo</th>
+                            <th>Data Creazione</th>
+                            <th>Azioni</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {users.map(user => (
+                            <tr key={user.id}>
+                                <td>{user.username}</td>
+                                <td>{user.full_name}</td>
+                                <td>
+                                    <span className={`role-badge ${user.role}`}>
+                                        {user.role}
+                                    </span>
+                                </td>
+                                <td>{new Date(user.created_at).toLocaleDateString()}</td>
+                                <td className="actions-cell">
+                                    <button className="action-btn" title="Modifica Ruolo" onClick={() => openModal(user, 'role')}>
+                                        <Edit size={18} />
+                                    </button>
+                                    <button className="action-btn" title="Modifica Password" onClick={() => openModal(user, 'password')}>
+                                        <KeyRound size={18} />
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            )}
+        </div>
+      </div>
+
+      {isRoleModalOpen && selectedUser && (
+          <UserModal user={selectedUser} onClose={closeModal} onSave={handleUpdateRole} />
+      )}
+      {isPasswordModalOpen && selectedUser && (
+          <UserModal user={selectedUser} onClose={closeModal} onSave={handleUpdatePassword} isPasswordModal />
+      )}
+
+    </div>
+  );
+};
+
+export default ModernSettingsPage;

--- a/src/components/ModernSidebar.js
+++ b/src/components/ModernSidebar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {
   BarChart3, Users, Trophy, Package, UserPlus, Zap, Upload, History,
-  LogOut, Moon, Sun, X, User, TrendingUp
+  Settings, LogOut, Moon, Sun, X, User, TrendingUp
 } from 'lucide-react';
 
 const ModernSidebar = ({
@@ -17,6 +17,10 @@ const ModernSidebar = ({
     { id: 'fastweb', label: 'Fastweb', icon: Zap, color: 'from-orange-500 to-orange-600', description: 'Contratti Fastweb' },
     { id: 'historical-analysis', label: 'Analisi Storia', icon: History, color: 'from-purple-500 to-purple-600', description: 'Analisi storica dei dati' },
     { id: 'files', label: 'Gestione File', icon: Upload, color: 'from-indigo-500 to-indigo-600', description: 'Upload e gestione' }
+  ];
+
+  const adminMenuItems = [
+    { id: 'settings', label: 'Impostazioni', icon: Settings, color: 'from-gray-500 to-gray-600', description: 'Gestione utenti' }
   ];
 
   const handleItemClick = (itemId) => {
@@ -91,6 +95,30 @@ const ModernSidebar = ({
               );
             })}
           </div>
+
+          {currentUser?.role === 'admin' && (
+            <div className="nav-section">
+              <span className="section-title">Impostazioni</span>
+              {adminMenuItems.map((item) => {
+                const Icon = item.icon;
+                const isActive = activeSection === item.id;
+                return (
+                  <button key={item.id} className={`nav-item ${isActive ? 'active' : ''}`} onClick={() => handleItemClick(item.id)}>
+                    <div className={`nav-icon bg-gradient-to-r ${item.color}`}>
+                      <Icon size={20} />
+                    </div>
+                    {(!isCollapsed || !isMobile) && (
+                      <div className="nav-content">
+                        <span className="nav-label">{item.label}</span>
+                        <span className="nav-description">{item.description}</span>
+                      </div>
+                    )}
+                    {isActive && <div className="active-indicator" />}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </nav>
 
         <div className="sidebar-footer">

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -624,6 +624,53 @@ class ApiService {
   }
 
   // ================================
+  // ADMIN METHODS
+  // ================================
+
+  /**
+   * Ottieni tutti gli utenti (solo admin)
+   */
+  async getUsers() {
+    // TODO: Il backend deve implementare questo endpoint
+    // GET /api/users
+    // return await this.makeRequest('users');
+    console.warn("apiService.getUsers() è mockato.");
+    return Promise.resolve([
+        { id: 1, username: 'admin', full_name: 'Admin User', role: 'admin', created_at: '2023-01-01' },
+        { id: 2, username: 'viewer', full_name: 'Viewer User', role: 'viewer', created_at: '2023-01-02' },
+    ]);
+  }
+
+  /**
+   * Aggiorna il ruolo di un utente (solo admin)
+   */
+  async updateUserRole(userId, role) {
+    // TODO: Il backend deve implementare questo endpoint
+    // PUT /api/users/{userId}/role
+    // return await this.makeRequest(`users/${userId}/role`, {
+    //   method: 'PUT',
+    //   body: JSON.stringify({ role }),
+    // });
+    console.warn("apiService.updateUserRole() è mockato.");
+    return Promise.resolve({ success: true, message: 'Ruolo aggiornato con successo' });
+  }
+
+  /**
+   * Aggiorna la password di un utente (solo admin)
+   */
+  async adminUpdateUserPassword(userId, newPassword) {
+    // TODO: Il backend deve implementare questo endpoint
+    // PUT /api/users/{userId}/password
+    // return await this.makeRequest(`users/${userId}/password`, {
+    //   method: 'PUT',
+    //   body: JSON.stringify({ new_password: newPassword }),
+    // });
+    console.warn("apiService.adminUpdateUserPassword() è mockato.");
+    return Promise.resolve({ success: true, message: 'Password aggiornata con successo' });
+  }
+
+
+  // ================================
   // BATCH OPERATIONS
   // ================================
 


### PR DESCRIPTION
- Create a new 'Impostazioni' section in the sidebar for administrators.
- Implement a user management page where admins can view a list of users.
- Add modals for changing user roles and passwords.
- Add mocked API functions in `apiService.js` for user management, as backend endpoints are not yet available.