### PR TITLE
fix: Correct settings icon background in sidebar

### DIFF
--- a/src/components/ModernSidebar.js
+++ b/src/components/ModernSidebar.js
@@ -20,7 +20,7 @@ const ModernSidebar = ({
   ];
 
   const adminMenuItems = [
-    { id: 'settings', label: 'Impostazioni', icon: Settings, color: 'from-gray-500 to-gray-600', description: 'Gestione utenti' }
+    { id: 'settings', label: 'Impostazioni', icon: Settings, color: 'from-slate-500 to-slate-600', description: 'Gestione utenti' }
   ];
 
   const handleItemClick = (itemId) => {


### PR DESCRIPTION
- Change the gradient color of the settings icon from gray to slate to provide better contrast and a more consistent look with other sidebar icons.