### PR TITLE
fix: Handle object response for getUsers API

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -631,7 +631,15 @@ class ApiService {
    * Ottieni tutti gli utenti (solo admin)
    */
   async getUsers() {
-    return await this.makeRequest('users');
+    const response = await this.makeRequest('users');
+    // Il backend restituisce un oggetto { success: true, 0: user1, 1: user2, ... }
+    // a causa della funzione helper `respondWithSuccess`. Lo convertiamo in un array.
+    if (response && typeof response === 'object' && response.success) {
+      delete response.success;
+      return Object.values(response);
+    }
+    // Fallback nel caso in cui la risposta sia già un array o non valida
+    return Array.isArray(response) ? response : [];
   }
 
   /**


### PR DESCRIPTION
- Modify the `getUsers` function in `apiService.js` to correctly parse the object-based response from the backend.
- This change converts the response object into a simple array of users, which fixes the `users.map is not a function` runtime error in the `ModernSettingsPage` component.