### PR TITLE
fix: Update settings icon color in sidebar

### DIFF
--- a/src/components/ModernSidebar.js
+++ b/src/components/ModernSidebar.js
@@ -20,7 +20,7 @@ const ModernSidebar = ({
   ];
 
   const adminMenuItems = [
-    { id: 'settings', label: 'Impostazioni', icon: Settings, color: 'from-slate-500 to-slate-600', description: 'Gestione utenti' }
+    { id: 'settings', label: 'Impostazioni', icon: Settings, color: 'from-purple-500 to-purple-600', description: 'Gestione utenti' }
   ];
 
   const handleItemClick = (itemId) => {


### PR DESCRIPTION
- Change the gradient color of the settings icon to a purple gradient that is already in use in the application.
- This ensures the color is part of the theme and should fix the visual bug where the icon had an incorrect background.