### PR TITLE
Support cookie-based authentication sessions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -695,21 +695,39 @@ function App() {
   useEffect(() => {
     const checkAuth = async () => {
       try {
+        let user = null;
+
         if (apiService.isAuthenticated()) {
-          const user = apiService.getCurrentUser();
-          if (user) {
-            setCurrentUser(user);
-            setIsAuthenticated(true);
-            
-            // Test connessione API
-            try {
-              await apiService.healthCheck();
-              console.log('✅ Connessione API verificata');
-            } catch (error) {
-              console.warn('⚠️ Problema connessione API:', error);
-              toast.warning('Connessione al server instabile');
+          user = apiService.getCurrentUser();
+
+          if (!user) {
+            const session = await apiService.restoreSession();
+            if (session.success) {
+              user = session.user;
             }
           }
+        } else {
+          const session = await apiService.restoreSession();
+          if (session.success) {
+            user = session.user;
+          }
+        }
+
+        if (user) {
+          setCurrentUser(user);
+          setIsAuthenticated(true);
+
+          // Test connessione API
+          try {
+            await apiService.healthCheck();
+            console.log('✅ Connessione API verificata');
+          } catch (error) {
+            console.warn('⚠️ Problema connessione API:', error);
+            toast.warning('Connessione al server instabile');
+          }
+        } else {
+          setCurrentUser(null);
+          setIsAuthenticated(false);
         }
       } catch (error) {
         console.error('Errore verifica autenticazione:', error);


### PR DESCRIPTION
## Summary
- replace localStorage-based token persistence with in-memory session tracking and always include credentials on API calls to support httpOnly cookie flows
- add a session restoration helper that fetches the current profile, clears auth state on 401s, and exposes it through the API service
- update the app bootstrap to rely on the new restoreSession logic before rendering authenticated areas

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cbd856c398832d815394c538a6d029