### PR TITLE
Gestisci pattern colonne mancanti con fallback sicuro

### DIFF
--- a/src/components/ColumnMappingModal.js
+++ b/src/components/ColumnMappingModal.js
@@ -24,6 +24,18 @@ const ColumnMappingModal = ({
     }));
   };
 
+  const getColumnPatterns = (column) => {
+    if (Array.isArray(column?.patterns)) {
+      return column.patterns;
+    }
+
+    if (Array.isArray(column?.possibleNames)) {
+      return column.possibleNames;
+    }
+
+    return [];
+  };
+
   const handleConfirmMapping = async () => {
     setIsProcessing(true);
     try {
@@ -79,35 +91,42 @@ const ColumnMappingModal = ({
               </h3>
               
               <div className="space-y-3">
-                {missingColumns.map((column, index) => (
-                  <div key={index} className="bg-white rounded p-3 border">
-                    <div className="flex justify-between items-start">
-                      <div className="flex-1">
-                        <span className="font-medium text-gray-900">
-                          {column.field}
-                        </span>
-                        <p className="text-sm text-gray-600 mt-1">
-                          Cercava: {column.possibleNames.join(', ')}
-                        </p>
-                      </div>
-                      
-                      {/* Manual Mapping Dropdown - Per implementazione futura */}
-                      <div className="ml-4 min-w-48">
-                        <select
-                          className="w-full p-2 border rounded text-sm bg-gray-50"
-                          value={manualMapping[column.field] || ''}
-                          onChange={(e) => handleManualMapping(column.field, e.target.value)}
-                          disabled={true} // Temporaneamente disabilitato
-                        >
-                          <option value="">🚧 Mappatura manuale non ancora implementata</option>
-                          {availableColumns.map((col, i) => (
-                            <option key={i} value={col}>{col}</option>
-                          ))}
-                        </select>
+                {missingColumns.map((column, index) => {
+                  const columnPatterns = getColumnPatterns(column);
+                  const patternsDescription = columnPatterns.length > 0
+                    ? columnPatterns.join(', ')
+                    : 'Nessun pattern disponibile';
+
+                  return (
+                    <div key={index} className="bg-white rounded p-3 border">
+                      <div className="flex justify-between items-start">
+                        <div className="flex-1">
+                          <span className="font-medium text-gray-900">
+                            {column.field}
+                          </span>
+                          <p className="text-sm text-gray-600 mt-1">
+                            Cercava: {patternsDescription}
+                          </p>
+                        </div>
+
+                        {/* Manual Mapping Dropdown - Per implementazione futura */}
+                        <div className="ml-4 min-w-48">
+                          <select
+                            className="w-full p-2 border rounded text-sm bg-gray-50"
+                            value={manualMapping[column.field] || ''}
+                            onChange={(e) => handleManualMapping(column.field, e.target.value)}
+                            disabled={true} // Temporaneamente disabilitato
+                          >
+                            <option value="">🚧 Mappatura manuale non ancora implementata</option>
+                            {availableColumns.map((col, i) => (
+                              <option key={i} value={col}>{col}</option>
+                            ))}
+                          </select>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
 

--- a/src/components/__tests__/ColumnMappingModal.test.js
+++ b/src/components/__tests__/ColumnMappingModal.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ColumnMappingModal from '../ColumnMappingModal';
+
+describe('ColumnMappingModal', () => {
+  it('gestisce dati inattesi nei pattern delle colonne senza andare in crash', () => {
+    const missingColumns = [
+      { field: 'Totale Vendite', patterns: 'valore-non-validato' },
+      { field: 'Numero Clienti', possibleNames: 'clienti_totali' }
+    ];
+
+    render(
+      <ColumnMappingModal
+        isOpen
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        onProceedWithoutMapping={jest.fn()}
+        missingColumns={missingColumns}
+        availableColumns={['Totale', 'Clienti']}
+      />
+    );
+
+    expect(screen.getByText('Colonne Non Trovate (2)')).toBeInTheDocument();
+    expect(screen.getByText('Totale Vendite')).toBeInTheDocument();
+    expect(screen.getByText('Numero Clienti')).toBeInTheDocument();
+    expect(screen.getAllByText(/Nessun pattern disponibile/)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- usa column.patterns con fallback sicuro quando si mostrano le colonne mancanti
- aggiungi controlli Array.isArray prima di effettuare join per evitare crash
- crea un test del modal che verifica la gestione di dati inattesi

## Testing
- npm test -- --watchAll=false --runTestsByPath src/components/__tests__/ColumnMappingModal.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cbdc46a29c832d879c7948a767a0fe