### PR TITLE
Configure explicit Babel React preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,10 @@
         "recharts": "^3.1.2",
         "web-vitals": "^2.1.4",
         "xlsx": "^0.18.5"
+      },
+      "devDependencies": {
+        "@babel/preset-react": "^7.26.3",
+        "eslint": "8.57.1"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
+    "@babel/preset-react": "^7.26.3",
     "eslint": "8.57.1"
   },
   "eslintConfig": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,16 @@ module.exports = (_env = {}, argv = {}) => {
           use: {
             loader: require.resolve('babel-loader'),
             options: {
-              presets: [require.resolve('babel-preset-react-app')],
+              presets: [
+                require.resolve('@babel/preset-env'),
+                [
+                  require.resolve('@babel/preset-react'),
+                  {
+                    runtime: 'automatic',
+                    importSource: 'react',
+                  },
+                ],
+              ],
               cacheDirectory: true,
               cacheCompression: false,
             },


### PR DESCRIPTION
## Summary
- replace the webpack babel-loader configuration with explicit @babel/preset-env and @babel/preset-react settings that enable the automatic JSX runtime
- add @babel/preset-react to the devDependencies so the loader configuration resolves

## Testing
- npm run dev
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe73d5bf0832d9128d1edb27f97f5