### PR TITLE
Remove credentials include from login request

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -258,7 +258,6 @@ class ApiService {
       const response = await this.makeRequest('login', {
         method: 'POST',
         body: JSON.stringify({ username, password }),
-        credentials: 'include',
       });
 
       if (!response.success) {


### PR DESCRIPTION
## Summary
- remove the explicit credentials include option from the login request configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc5a68b690832da0d1eb9858cc3663