### PR TITLE
Remove credentials option from restoreSession profile request

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -336,7 +336,6 @@ class ApiService {
     try {
       const response = await this.makeRequest('profile', {
         skipAuthErrorHandling: true,
-        credentials: 'include',
       });
 
       if (!response) {


### PR DESCRIPTION
## Summary
- remove the explicit `credentials: 'include'` option from the `restoreSession` profile request so it relies on default handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc5b028ccc832db726f805806c057a