### PR TITLE
Adjust Content-Type header logic

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -137,10 +137,13 @@ class ApiService {
     const isFormData = fetchOptions.body instanceof FormData;
 
     const headers = {
-      ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
       ...this.getAuthHeaders(),
       ...customHeaders,
     };
+
+    if (fetchOptions.body !== undefined && fetchOptions.body !== null && !isFormData && !('Content-Type' in headers)) {
+      headers['Content-Type'] = 'application/json';
+    }
 
     let credentials = requestedCredentials;
 


### PR DESCRIPTION
## Summary
- update API request header construction to only set Content-Type for JSON payloads
- ensure authentication and custom headers continue to merge correctly without forcing Content-Type on empty requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc5ec50b6c832d88ba4535bb7d8c10