### PR TITLE
Handle SQLite fallback when PDO extension is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm test         # Avvia Jest tramite react-scripts per i test component/integra
 
 - Definisci `VITE_API_BASE_URL` oppure il legacy `REACT_APP_API_BASE_URL` in un file `.env` per cambiare l'endpoint backend.
 - Il codice usa un resolver che controlla `import.meta.env` e, in fallback, `process.env`, così da funzionare sia con la nuova build Webpack sia con eventuali ambienti che usano ancora CRA.
+- Il backend PHP supporta un fallback SQLite impostando `DB_DRIVER=sqlite`, ma richiede che l'estensione `pdo_sqlite` sia disponibile. Se l'estensione manca, l'API tenta automaticamente di utilizzare la configurazione MySQL (`DB_HOST`, `DB_NAME`, `DB_USERNAME`, `DB_PASSWORD`).
 
 ## 5. Asset e routing
 


### PR DESCRIPTION
## Summary
- add a guard in the API bootstrap so the SQLite driver is used only when pdo_sqlite is available and automatically fall back to MySQL otherwise
- ensure the SQLite storage directory is created safely and keep schema migrations restricted to the MySQL path
- document in the README that using the SQLite fallback requires the pdo_sqlite extension or providing full MySQL settings

## Testing
- php -l api/index.php

------
https://chatgpt.com/codex/tasks/task_e_68ce6597127c832db070fc2799cce0ea