### PR TITLE
Add automatic schema bootstrap for login API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ Eseguire i seguenti test dopo il deploy dell'API aggiornata:
    - Ripeti l'operazione con un file già presente per assicurarti che l'aggiornamento funzioni ancora correttamente.
 
 Questi scenari garantiscono che solo gli amministratori possano caricare o aggiornare file mentre gli altri ruoli vengono bloccati lato server.
+
+## 9. Sincronizzazione automatica dello schema API
+
+- L'endpoint di login PHP (`api/index.php`) esegue ora automaticamente il bootstrap di `api/migrations/20240924_sync_schema.php` prima di interagire con il database. Il bootstrap verifica che la tabella `user_sessions` e la colonna `users.is_active` siano presenti, creando automaticamente gli elementi mancanti.
+- In caso di problemi durante la sincronizzazione lo script interrompe la richiesta con HTTP `503` e messaggio "Eseguire migrazione schema", evitando che vengano eseguite query non sicure.
+- Se per esigenze operative la sincronizzazione automatica viene disabilitata, assicurati di eseguire manualmente la migrazione (`api/migrations/20240924_sync_schema.php` con una connessione PDO valida) prima di riattivare le nuove policy di sessione.

--- a/api/index.php
+++ b/api/index.php
@@ -51,6 +51,17 @@ try {
     exit;
 }
 
+try {
+    require_once __DIR__ . '/migrations/20240924_sync_schema.php';
+} catch (Throwable $e) {
+    http_response_code(503);
+    echo json_encode([
+        'error' => 'Eseguire migrazione schema',
+        'details' => $e->getMessage(),
+    ]);
+    exit;
+}
+
 $method = $_SERVER['REQUEST_METHOD'];
 $path = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '', '/');
 $segments = $path ? explode('/', $path) : [];


### PR DESCRIPTION
## Summary
- load the schema sync migration when the API creates the PDO connection and return HTTP 503 if it fails
- extend the migration to create the user_sessions table when missing and bubble up errors
- document the automatic schema synchronization and manual fallback steps in the README

## Testing
- php -l api/index.php
- php -l api/migrations/20240924_sync_schema.php

------
https://chatgpt.com/codex/tasks/task_e_68ceef3bfe70832db716f4178019f343