### PR TITLE
Implement authenticated upload handling

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -146,6 +146,56 @@ function getJsonInput(): array
     return is_array($input) ? $input : [];
 }
 
+function getTableColumns(PDO $pdo, string $table): array
+{
+    static $cache = [];
+
+    if (!isset($cache[$table])) {
+        $stmt = $pdo->prepare(
+            'SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?'
+        );
+        $stmt->execute([$table]);
+
+        $cache[$table] = array_map('strtolower', $stmt->fetchAll(PDO::FETCH_COLUMN));
+    }
+
+    return $cache[$table];
+}
+
+function requireAuthenticatedUser(PDO $pdo, bool $mustBeAdmin = false): ?array
+{
+    $token = getAuthorizationToken();
+
+    if (!$token) {
+        http_response_code(401);
+        echo json_encode(['success' => false, 'error' => 'Token mancante']);
+        return null;
+    }
+
+    $stmt = $pdo->prepare('
+        SELECT u.id, u.username, u.role, u.full_name
+        FROM users u
+        JOIN user_sessions s ON u.id = s.user_id
+        WHERE s.session_token = ? AND s.expires_at > NOW()
+    ');
+    $stmt->execute([$token]);
+    $user = $stmt->fetch();
+
+    if (!$user) {
+        http_response_code(401);
+        echo json_encode(['success' => false, 'error' => 'Sessione non valida o scaduta']);
+        return null;
+    }
+
+    if ($mustBeAdmin && strtolower((string)($user['role'] ?? '')) !== 'admin') {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'error' => 'Permessi insufficienti']);
+        return null;
+    }
+
+    return $user;
+}
+
 // === HANDLERS ===
 
 function handleLogin(PDO $pdo): void
@@ -277,6 +327,207 @@ function handleFileData(PDO $pdo): void
 
 function handleFileUpload(PDO $pdo): void
 {
-    echo json_encode(['success' => true, 'message' => 'Upload endpoint attivo']);
+    $user = requireAuthenticatedUser($pdo, true);
+    if (!$user) {
+        return;
+    }
+
+    $input = getJsonInput();
+    $fileData = $input['fileData'] ?? null;
+
+    if (!is_array($fileData)) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Payload "fileData" mancante o non valido']);
+        return;
+    }
+
+    $requiredFields = ['name', 'date', 'size', 'data'];
+    foreach ($requiredFields as $field) {
+        if (!array_key_exists($field, $fileData)) {
+            http_response_code(400);
+            echo json_encode(['success' => false, 'error' => "Campo obbligatorio mancante: {$field}"]);
+            return;
+        }
+    }
+
+    $fileName = trim((string)$fileData['name']);
+    $fileDate = trim((string)$fileData['date']);
+    $fileSize = is_numeric($fileData['size']) ? (int)$fileData['size'] : null;
+    $parsedData = $fileData['data'];
+
+    if ($fileName === '' || $fileDate === '') {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Nome file o data non validi']);
+        return;
+    }
+
+    if ($fileSize === null || $fileSize < 0) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Dimensione file non valida']);
+        return;
+    }
+
+    if (!is_array($parsedData)) {
+        http_response_code(400);
+        echo json_encode(['success' => false, 'error' => 'Struttura "data" non valida']);
+        return;
+    }
+
+    $displayDate = isset($fileData['displayDate']) ? trim((string)$fileData['displayDate']) : null;
+    $displayDate = $displayDate !== '' ? $displayDate : null;
+
+    $metadata = [];
+    if (isset($fileData['metadata']) && is_array($fileData['metadata'])) {
+        $metadata = $fileData['metadata'];
+    } elseif (isset($parsedData['metadata']) && is_array($parsedData['metadata'])) {
+        $metadata = $parsedData['metadata'];
+    }
+
+    $agents = isset($parsedData['agents']) && is_array($parsedData['agents']) ? $parsedData['agents'] : [];
+    $smData = isset($parsedData['smData']) && is_array($parsedData['smData']) ? $parsedData['smData'] : [];
+
+    $totals = [
+        'agents' => isset($metadata['totalAgents']) ? (int)$metadata['totalAgents'] : count($agents),
+        'sms' => isset($metadata['totalSMs']) ? (int)$metadata['totalSMs'] : count($smData),
+        'revenue' => isset($metadata['totalRevenue']) ? (float)$metadata['totalRevenue'] : 0.0,
+        'rush' => isset($metadata['totalRush']) ? (float)$metadata['totalRush'] : 0.0,
+        'newClients' => isset($metadata['totalNewClients']) ? (int)$metadata['totalNewClients'] : 0,
+        'fastweb' => isset($metadata['totalFastweb']) ? (int)$metadata['totalFastweb'] : 0,
+    ];
+
+    $totalInflow = isset($metadata['totalInflow']) ? (float)$metadata['totalInflow'] : $totals['rush'];
+
+    $jsonOptions = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES;
+
+    $fileDataJson = json_encode($parsedData, $jsonOptions);
+    $metadataPayload = !empty($metadata) ? $metadata : new stdClass();
+    $metadataJson = json_encode($metadataPayload, $jsonOptions);
+    $agentsJson = json_encode($agents, $jsonOptions);
+    $smRankingJson = json_encode($smData, $jsonOptions);
+
+    if ($fileDataJson === false || $metadataJson === false || $agentsJson === false || $smRankingJson === false) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'Errore nella serializzazione dei dati JSON']);
+        return;
+    }
+
+    $columns = getTableColumns($pdo, 'uploaded_files');
+    $hasColumn = function (string $column) use ($columns): bool {
+        return in_array(strtolower($column), $columns, true);
+    };
+
+    if (!$hasColumn('file_date') || !$hasColumn('file_name')) {
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'Struttura tabella "uploaded_files" non valida']);
+        return;
+    }
+
+    $now = (new DateTime())->format('Y-m-d H:i:s');
+
+    $commonData = [];
+    $commonData['file_name'] = $fileName;
+    if ($hasColumn('display_date')) {
+        $commonData['display_date'] = $displayDate;
+    }
+    if ($hasColumn('file_size')) {
+        $commonData['file_size'] = $fileSize;
+    }
+    if ($hasColumn('uploaded_by')) {
+        $commonData['uploaded_by'] = (int)$user['id'];
+    }
+    if ($hasColumn('total_agents')) {
+        $commonData['total_agents'] = $totals['agents'];
+    }
+    if ($hasColumn('total_sms')) {
+        $commonData['total_sms'] = $totals['sms'];
+    }
+    if ($hasColumn('total_revenue')) {
+        $commonData['total_revenue'] = $totals['revenue'];
+    }
+    if ($hasColumn('total_inflow')) {
+        $commonData['total_inflow'] = $totalInflow;
+    }
+    if ($hasColumn('total_new_clients')) {
+        $commonData['total_new_clients'] = $totals['newClients'];
+    }
+    if ($hasColumn('total_fastweb')) {
+        $commonData['total_fastweb'] = $totals['fastweb'];
+    }
+    if ($hasColumn('total_rush')) {
+        $commonData['total_rush'] = $totals['rush'];
+    }
+    if ($hasColumn('file_data')) {
+        $commonData['file_data'] = $fileDataJson;
+    }
+    if ($hasColumn('metadata')) {
+        $commonData['metadata'] = $metadataJson;
+    }
+    if ($hasColumn('agents_data')) {
+        $commonData['agents_data'] = $agentsJson;
+    }
+    if ($hasColumn('sm_ranking')) {
+        $commonData['sm_ranking'] = $smRankingJson;
+    }
+    if ($hasColumn('upload_date')) {
+        $commonData['upload_date'] = $now;
+    }
+
+    try {
+        $pdo->beginTransaction();
+
+        $stmt = $pdo->prepare('SELECT id FROM uploaded_files WHERE file_date = ? LIMIT 1');
+        $stmt->execute([$fileDate]);
+        $existingId = $stmt->fetchColumn();
+
+        if ($existingId) {
+            $setParts = [];
+            foreach ($commonData as $column => $_value) {
+                $setParts[] = sprintf('%s = :%s', $column, $column);
+            }
+
+            $sql = 'UPDATE uploaded_files SET ' . implode(', ', $setParts) . ' WHERE id = :id';
+            $updateStmt = $pdo->prepare($sql);
+
+            foreach ($commonData as $column => $value) {
+                $updateStmt->bindValue(':' . $column, $value);
+            }
+            $updateStmt->bindValue(':id', (int)$existingId, PDO::PARAM_INT);
+            $updateStmt->execute();
+
+            $action = 'updated';
+        } else {
+            $insertData = ['file_date' => $fileDate] + $commonData;
+
+            $columnsSql = implode(', ', array_keys($insertData));
+            $placeholders = implode(', ', array_map(function ($column) {
+                return ':' . $column;
+            }, array_keys($insertData)));
+
+            $sql = sprintf('INSERT INTO uploaded_files (%s) VALUES (%s)', $columnsSql, $placeholders);
+            $insertStmt = $pdo->prepare($sql);
+
+            foreach ($insertData as $column => $value) {
+                $insertStmt->bindValue(':' . $column, $value);
+            }
+
+            $insertStmt->execute();
+            $action = 'created';
+        }
+
+        $pdo->commit();
+
+        if ($action === 'created') {
+            http_response_code(201);
+        }
+
+        echo json_encode(['success' => true, 'action' => $action]);
+    } catch (Throwable $e) {
+        if ($pdo->inTransaction()) {
+            $pdo->rollBack();
+        }
+
+        http_response_code(500);
+        echo json_encode(['success' => false, 'error' => 'Errore durante il salvataggio del file', 'details' => $e->getMessage()]);
+    }
 }
 ?>

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -539,11 +539,11 @@ class ApiService {
     try {
       logDebug('💾 Saving file:', fileData.name, fileData.date);
       
-      const response = await this.makeRequest('upload', {
+      const response = await this.makeRequest('uploads', {
         method: 'POST',
         body: JSON.stringify({ fileData }),
       });
-      
+
       logDebug('✅ File saved successfully:', response);
       return response;
     } catch (error) {


### PR DESCRIPTION
## Summary
- update the dashboard API client to target the new uploads endpoint for file saves
- implement authenticated file upload handling on the PHP API, including validation, JSON serialization, and persistence of totals

## Testing
- npm run lint
- php -l api/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d12097af38832d9f047a920d255399