### PR TITLE
Implement file upload persistence and client handling

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -539,13 +539,23 @@ class ApiService {
     try {
       logDebug('💾 Saving file:', fileData.name, fileData.date);
       
-      const response = await this.makeRequest('upload', {
+      const response = await this.makeRequest('uploads', {
         method: 'POST',
         body: JSON.stringify({ fileData }),
       });
-      
-      logDebug('✅ File saved successfully:', response);
-      return response;
+
+      const success = response?.success === true;
+      const action = response?.action ?? (success ? 'created' : undefined);
+
+      if (!success) {
+        const errorMessage = response?.error || 'Impossibile salvare il file';
+        throw new ApiError(errorMessage, response?.statusCode ?? 500, response);
+      }
+
+      const result = { success, action };
+
+      logDebug('✅ File saved successfully:', result);
+      return result;
     } catch (error) {
       logError('❌ Error saving file:', error);
       throw error;


### PR DESCRIPTION
## Summary
- update the front-end API service to call POST /uploads and surface the success/action result
- implement the PHP upload handler with authentication, validation, JSON serialization, and insert/update logic
- return detailed error messages and HTTP status codes for invalid tokens or payloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1275f5958832da7d9646e725612b5