### PR TITLE
Preserve parsed metadata totals when normalizing uploads

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -212,8 +212,8 @@ function normalizeUploadedFile(array $file): array
     }
 
     $metadata = array_merge(
-        is_array($metadataFromColumn) ? $metadataFromColumn : [],
-        $totalsForClient
+        $totalsForClient,
+        is_array($metadataFromColumn) ? $metadataFromColumn : []
     );
 
     if (!array_key_exists('totalRush', $metadata)) {


### PR DESCRIPTION
## Summary
- keep client-side metadata totals when normalizing uploads by letting metadata from the JSON override database fallbacks

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d12fb33384832d81c4bf2995cdd270