### PR TITLE
Fix health check toast notification

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -769,7 +769,7 @@ function App() {
             console.log('✅ Connessione API verificata');
           } catch (error) {
             console.warn('⚠️ Problema connessione API:', error);
-            toast.warning('Connessione al server instabile');
+            toast.error('Connessione al server instabile');
           }
         } else {
           setCurrentUser(null);


### PR DESCRIPTION
## Summary
- replace the unsupported toast.warning invocation in the health-check catch block with toast.error so the notification uses a supported react-hot-toast API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d16cfa93c4832d943b0d629d92c279