### PR TITLE
Ensure legacy upload columns exist

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -145,6 +145,10 @@ function ensureBasicSchema(PDO $pdo): void
         'total_new_clients' => 'INT NULL',
         'total_fastweb' => 'INT NULL',
         'total_rush' => 'DECIMAL(15,2) NULL',
+        'display_date' => 'VARCHAR(20) NULL',
+        'file_size' => 'INT NULL',
+        'upload_date' => 'DATETIME NULL',
+        'uploaded_by' => 'INT NULL',
     ];
 
     try {


### PR DESCRIPTION
## Summary
- add schema sync definitions for display_date, file_size, upload_date, and uploaded_by in the uploaded_files schema helper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcf3658324832dad3fdee5ef6c210f