### PR TITLE
Add guard to avoid unnecessary session restore requests

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -445,6 +445,10 @@ class ApiService {
    * Prova a ripristinare una sessione attiva utilizzando cookie/token
    */
   async restoreSession() {
+    if (!this.token && !this.sessionActive) {
+      return { success: false };
+    }
+
     try {
       const response = await this.makeRequest('profile', {
         skipAuthErrorHandling: true,


### PR DESCRIPTION
## Summary
- add an early return in the API service session restoration when no token or active session is available to avoid unnecessary requests
- preserve existing session persistence logic so the current user and storage updates still occur after a successful API call

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcf3ee95fc832d828f841a39e1131b